### PR TITLE
feat(mobile): Mobile Investigation Shell for field investigators

### DIFF
--- a/src/client/components/investigation/CommunicationAnalysis.tsx
+++ b/src/client/components/investigation/CommunicationAnalysis.tsx
@@ -24,6 +24,7 @@ interface CommunicationAnalysisProps {
   evidence: EvidenceItem[];
   onCommunicationPatternDetected?: (patterns: CommunicationPattern[]) => void;
   onOpenCaseFolder?: () => void;
+  mobileMode?: boolean;
 }
 
 export interface CommunicationPattern {
@@ -56,6 +57,7 @@ export const CommunicationAnalysis: React.FC<CommunicationAnalysisProps> = ({
   investigation,
   evidence,
   onCommunicationPatternDetected,
+  mobileMode,
 }) => {
   const [communicationPatterns, setCommunicationPatterns] = useState<CommunicationPattern[]>([]);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
@@ -283,27 +285,29 @@ export const CommunicationAnalysis: React.FC<CommunicationAnalysisProps> = ({
 
   return (
     <Box className={styles.autoGen30} style={{ backgroundColor: 'var(--lq-surface-1)' }}>
-      <Surface variant="glass" p="xl" className={styles.autoGen31}>
-        <Flex justify="between" align="center">
-          <Stack gap="none">
-            <LqText variant="h2" weight="bold">
-              Communication Forensics
-            </LqText>
-            <Flex align="center" gap="sm">
-              <LqText variant="xs" color="muted" weight="bold">
-                SIGNAL INTELLIGENCE • NETWORK ANALYSIS
+      {!mobileMode && (
+        <Surface variant="glass" p="xl" className={styles.autoGen31}>
+          <Flex justify="between" align="center">
+            <Stack gap="none">
+              <LqText variant="h2" weight="bold">
+                Communication Forensics
               </LqText>
-              {lastRunAt && (
-                <Badge>{`LAST SCAN: ${new Date(lastRunAt).toLocaleTimeString()}`}</Badge>
-              )}
-            </Flex>
-          </Stack>
-          <Button variant="primary" onClick={analyzeCommunications} disabled={isAnalyzing}>
-            <Activity className={isAnalyzing ? 'animate-spin-slow' : ''} size={18} />
-            {isAnalyzing ? 'Analyzing Network...' : 'Initiate Communication Scan'}
-          </Button>
-        </Flex>
-      </Surface>
+              <Flex align="center" gap="sm">
+                <LqText variant="xs" color="muted" weight="bold">
+                  SIGNAL INTELLIGENCE • NETWORK ANALYSIS
+                </LqText>
+                {lastRunAt && (
+                  <Badge>{`LAST SCAN: ${new Date(lastRunAt).toLocaleTimeString()}`}</Badge>
+                )}
+              </Flex>
+            </Stack>
+            <Button variant="primary" onClick={analyzeCommunications} disabled={isAnalyzing}>
+              <Activity className={isAnalyzing ? 'animate-spin-slow' : ''} size={18} />
+              {isAnalyzing ? 'Analyzing Network...' : 'Initiate Communication Scan'}
+            </Button>
+          </Flex>
+        </Surface>
+      )}
 
       <Box p="xl">
         {isAnalyzing && (

--- a/src/client/components/investigation/ForensicDocumentAnalyzer.tsx
+++ b/src/client/components/investigation/ForensicDocumentAnalyzer.tsx
@@ -148,12 +148,14 @@ interface ForensicDocumentAnalyzerProps {
   documentId: string;
   onAnalysisComplete?: (analysis: ForensicAnalysis) => void;
   caseContext?: ForensicCaseContext;
+  mobileMode?: boolean;
 }
 
 export const ForensicDocumentAnalyzer: React.FC<ForensicDocumentAnalyzerProps> = ({
   documentId,
   onAnalysisComplete,
   caseContext,
+  mobileMode,
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -235,445 +237,451 @@ export const ForensicDocumentAnalyzer: React.FC<ForensicDocumentAnalyzerProps> =
         </Box>
 
         {/* Forensic Analysis Panel */}
-        <Box style={{ width: 450 }} className={styles.autoGen99}>
-          <Surface variant="glass" className={styles.autoGen100} style={{ height: '100%' }}>
-            {!analysis && !isAnalyzing ? (
-              <Stack align="center" p="xxl" gap="xl" style={{ height: '100%' }}>
-                <Fingerprint size={64} className={styles.autoGen101} />
-                <Stack gap="sm">
-                  <LqText variant="display" weight="bold">
-                    Forensic Verification Required
-                  </LqText>
-                  <LqText variant="xs" color="muted">
-                    Run forensic analysis to generate authenticity signals and extract metadata.
-                  </LqText>
-                </Stack>
-                <Button
-                  variant="primary"
-                  size="lg"
-                  onClick={startForensicAnalysis}
-                  disabled={!documentId}
-                >
-                  <Zap size={18} /> Initiate Analysis
-                </Button>
-              </Stack>
-            ) : isAnalyzing ? (
-              <Stack align="center" p="xxl" gap="xl" style={{ height: '100%' }}>
-                <Loader2 size={64} className={styles.autoGen102} />
-                <Stack gap="sm">
-                  <LqText variant="display" weight="bold">
-                    Analyzing Forensic Signals...
-                  </LqText>
-                  <LqText variant="xs" color="muted">
-                    Processing metadata, linguistic patterns, and cross-references.
-                  </LqText>
-                </Stack>
-              </Stack>
-            ) : (
-              <Stack p="xl" gap="xl">
-                {/* Authenticity Matrix */}
-                <Surface variant="glass-highlight" p="lg" className={styles.autoGen103}>
-                  <Stack gap="md">
-                    <Flex justify="between" align="center">
-                      <LqText variant="small" weight="bold" color="muted">
-                        AUTHENTICITY INDEX
-                      </LqText>
-                      <Flex align="center" gap="sm">
-                        {analysis!.authenticity.verdict === 'authentic' && (
-                          <CheckCircle className={styles.autoGen104} size={18} />
-                        )}
-                        {analysis!.authenticity.verdict === 'suspicious' && (
-                          <AlertTriangle className={styles.autoGen105} size={18} />
-                        )}
-                        {analysis!.authenticity.verdict === 'forged' && (
-                          <XCircle className={styles.autoGen106} size={18} />
-                        )}
-                        <LqText
-                          variant="h2"
-                          weight="bold"
-                          color={analysis!.authenticity.score >= 90 ? 'success' : 'accent'}
-                        >
-                          {analysis!.authenticity.score}%
-                        </LqText>
-                      </Flex>
-                    </Flex>
-
-                    <Box className={styles.autoGen107}>
-                      <Box
-                        className={styles.autoGen107Bar}
-                        style={{
-                          width: `${analysis!.authenticity.score}%`,
-                          backgroundColor:
-                            analysis!.authenticity.score >= 90
-                              ? 'var(--lq-success)'
-                              : 'var(--lq-accent)',
-                        }}
-                      />
-                    </Box>
-
-                    <Flex justify="between" align="center">
-                      <LqText variant="xs" weight="bold">
-                        Verdict: {getVerdictLabel(analysis!.authenticity.verdict)}
-                      </LqText>
-                      <Button variant="ghost" size="sm" onClick={() => toggleSection('factors')}>
-                        {expandedSections.factors ? (
-                          <ChevronUp size={12} />
-                        ) : (
-                          <ChevronDown size={12} />
-                        )}
-                        {expandedSections.factors ? 'Hide' : 'View'} Factors
-                      </Button>
-                    </Flex>
-
-                    {expandedSections.factors && (
-                      <Stack gap="sm" mt="sm">
-                        {analysis!.authenticity.factors.map((f: AuthenticityFactor, i: number) => (
-                          <Surface key={i} variant="glass" p="sm">
-                            <Flex justify="between">
-                              <LqText variant="xs" weight="bold">
-                                {f.type.replace('_', ' ')}
-                              </LqText>
-                              <LqText variant="xs" weight="bold">
-                                {f.score}%
-                              </LqText>
-                            </Flex>
-                            <LqText variant="xs" color="muted">
-                              {f.description}
-                            </LqText>
-                          </Surface>
-                        ))}
-                      </Stack>
-                    )}
+        {!mobileMode && (
+          <Box style={{ width: 450 }} className={styles.autoGen99}>
+            <Surface variant="glass" className={styles.autoGen100} style={{ height: '100%' }}>
+              {!analysis && !isAnalyzing ? (
+                <Stack align="center" p="xxl" gap="xl" style={{ height: '100%' }}>
+                  <Fingerprint size={64} className={styles.autoGen101} />
+                  <Stack gap="sm">
+                    <LqText variant="display" weight="bold">
+                      Forensic Verification Required
+                    </LqText>
+                    <LqText variant="xs" color="muted">
+                      Run forensic analysis to generate authenticity signals and extract metadata.
+                    </LqText>
                   </Stack>
-                </Surface>
-
-                <Tabs
-                  tabs={[
-                    { key: 'dashboard', label: 'Dashboard', icon: <BarChart3 size={16} /> },
-                    {
-                      key: 'entities',
-                      label: 'Entities',
-                      icon: <User size={16} />,
-                      count: analysis!.entities.length,
-                    },
-                    {
-                      key: 'patterns',
-                      label: 'Patterns',
-                      icon: <Activity size={16} />,
-                      count: analysis!.patterns.length,
-                    },
-                    {
-                      key: 'anomalies',
-                      label: 'Anomalies',
-                      icon: <ShieldAlert size={16} />,
-                      count: analysis!.anomalies.length,
-                    },
-                    { key: 'metadata', label: 'Metadata', icon: <FileText size={16} /> },
-                  ]}
-                  activeTab={activeTab}
-                  onChange={(k) =>
-                    setActiveTab(
-                      k as 'dashboard' | 'entities' | 'patterns' | 'anomalies' | 'metadata',
-                    )
-                  }
-                  className={styles.autoGen108}
-                />
-
-                <Box>
-                  {activeTab === 'dashboard' && (
-                    <Stack gap="xl">
-                      <Grid cols={{ sm: 1, md: 2 }} gap="md">
-                        <Surface variant="glass-highlight" p="md">
-                          <Stack gap="sm">
-                            <LqText variant="xs" weight="bold" color="muted">
-                              TECHNICAL FORENSICS
-                            </LqText>
-                            <Stack gap="xs">
-                              <Flex justify="between">
-                                <LqText variant="xs" color="muted">
-                                  Producer
-                                </LqText>
-                                <LqText variant="xs" weight="bold">
-                                  {metrics?.technical?.producer || '—'}
-                                </LqText>
-                              </Flex>
-                              <Flex justify="between">
-                                <LqText variant="xs" color="muted">
-                                  Creator
-                                </LqText>
-                                <LqText variant="xs" weight="bold">
-                                  {metrics?.technical?.creator || '—'}
-                                </LqText>
-                              </Flex>
-                              <Flex justify="between">
-                                <LqText variant="xs" color="muted">
-                                  Created
-                                </LqText>
-                                <LqText variant="xs" weight="bold">
-                                  {metrics?.technical?.creationDate || '—'}
-                                </LqText>
-                              </Flex>
-                              <Flex justify="between">
-                                <LqText variant="xs" color="muted">
-                                  Pages
-                                </LqText>
-                                <LqText variant="xs" weight="bold">
-                                  {metrics?.technical?.pageCount || '—'}
-                                </LqText>
-                              </Flex>
-                            </Stack>
-                            <Button variant="secondary" size="sm" onClick={() => {}}>
-                              <Download size={10} /> Export Signal Data
-                            </Button>
-                          </Stack>
-                        </Surface>
-
-                        <Surface variant="glass-highlight" p="md">
-                          <Stack gap="sm">
-                            <LqText variant="xs" weight="bold" color="muted">
-                              LINGUISTIC / SENTIMENT
-                            </LqText>
-                            <Stack gap="xs">
-                              <Flex justify="between">
-                                <LqText variant="xs" color="muted">
-                                  FKGL (Readability)
-                                </LqText>
-                                <LqText variant="xs" weight="bold">
-                                  {metrics?.linguistic?.readabilityFKGL || '—'}
-                                </LqText>
-                              </Flex>
-                              <Flex justify="between">
-                                <LqText variant="xs" color="muted">
-                                  Sentiment
-                                </LqText>
-                                <LqText variant="xs" weight="bold">
-                                  {(metrics?.linguistic?.sentiment || 'neutral')
-                                    .charAt(0)
-                                    .toUpperCase() +
-                                    (metrics?.linguistic?.sentiment || 'neutral').slice(1)}
-                                </LqText>
-                              </Flex>
-                              <Flex justify="between">
-                                <LqText variant="xs" color="muted">
-                                  TTR
-                                </LqText>
-                                <LqText variant="xs" weight="bold">
-                                  {metrics?.linguistic?.typeTokenRatio || '—'}%
-                                </LqText>
-                              </Flex>
-                              <Flex justify="between">
-                                <LqText variant="xs" color="muted">
-                                  Risk Score
-                                </LqText>
-                                <LqText variant="xs" weight="bold">
-                                  {metrics?.network?.riskScore || '—'}%
-                                </LqText>
-                              </Flex>
-                            </Stack>
-                          </Stack>
-                        </Surface>
-                      </Grid>
-
-                      <Surface variant="glass" p="md">
-                        <LqText
-                          variant="xs"
-                          weight="bold"
-                          color="muted"
-                          style={{ marginBottom: 'lg' }}
-                        >
-                          SENTIMENT DISTRIBUTION
+                  <Button
+                    variant="primary"
+                    size="lg"
+                    onClick={startForensicAnalysis}
+                    disabled={!documentId}
+                  >
+                    <Zap size={18} /> Initiate Analysis
+                  </Button>
+                </Stack>
+              ) : isAnalyzing ? (
+                <Stack align="center" p="xxl" gap="xl" style={{ height: '100%' }}>
+                  <Loader2 size={64} className={styles.autoGen102} />
+                  <Stack gap="sm">
+                    <LqText variant="display" weight="bold">
+                      Analyzing Forensic Signals...
+                    </LqText>
+                    <LqText variant="xs" color="muted">
+                      Processing metadata, linguistic patterns, and cross-references.
+                    </LqText>
+                  </Stack>
+                </Stack>
+              ) : (
+                <Stack p="xl" gap="xl">
+                  {/* Authenticity Matrix */}
+                  <Surface variant="glass-highlight" p="lg" className={styles.autoGen103}>
+                    <Stack gap="md">
+                      <Flex justify="between" align="center">
+                        <LqText variant="small" weight="bold" color="muted">
+                          AUTHENTICITY INDEX
                         </LqText>
-                        <Box className={styles.autoGen109}>
-                          <ResponsiveContainer width="100%" height="100%">
-                            <PieChart>
-                              <Pie
-                                data={[
-                                  { name: 'Pos', value: summary?.sentimentCounts?.positive || 0 },
-                                  { name: 'Neu', value: summary?.sentimentCounts?.neutral || 0 },
-                                  { name: 'Neg', value: summary?.sentimentCounts?.negative || 0 },
-                                ]}
-                                dataKey="value"
-                                stroke="none"
-                                outerRadius={60}
-                                label
-                              >
-                                {['var(--lq-success)', 'var(--lq-text-dim)', 'var(--lq-error)'].map(
-                                  (c, i) => (
+                        <Flex align="center" gap="sm">
+                          {analysis!.authenticity.verdict === 'authentic' && (
+                            <CheckCircle className={styles.autoGen104} size={18} />
+                          )}
+                          {analysis!.authenticity.verdict === 'suspicious' && (
+                            <AlertTriangle className={styles.autoGen105} size={18} />
+                          )}
+                          {analysis!.authenticity.verdict === 'forged' && (
+                            <XCircle className={styles.autoGen106} size={18} />
+                          )}
+                          <LqText
+                            variant="h2"
+                            weight="bold"
+                            color={analysis!.authenticity.score >= 90 ? 'success' : 'accent'}
+                          >
+                            {analysis!.authenticity.score}%
+                          </LqText>
+                        </Flex>
+                      </Flex>
+
+                      <Box className={styles.autoGen107}>
+                        <Box
+                          className={styles.autoGen107Bar}
+                          style={{
+                            width: `${analysis!.authenticity.score}%`,
+                            backgroundColor:
+                              analysis!.authenticity.score >= 90
+                                ? 'var(--lq-success)'
+                                : 'var(--lq-accent)',
+                          }}
+                        />
+                      </Box>
+
+                      <Flex justify="between" align="center">
+                        <LqText variant="xs" weight="bold">
+                          Verdict: {getVerdictLabel(analysis!.authenticity.verdict)}
+                        </LqText>
+                        <Button variant="ghost" size="sm" onClick={() => toggleSection('factors')}>
+                          {expandedSections.factors ? (
+                            <ChevronUp size={12} />
+                          ) : (
+                            <ChevronDown size={12} />
+                          )}
+                          {expandedSections.factors ? 'Hide' : 'View'} Factors
+                        </Button>
+                      </Flex>
+
+                      {expandedSections.factors && (
+                        <Stack gap="sm" mt="sm">
+                          {analysis!.authenticity.factors.map(
+                            (f: AuthenticityFactor, i: number) => (
+                              <Surface key={i} variant="glass" p="sm">
+                                <Flex justify="between">
+                                  <LqText variant="xs" weight="bold">
+                                    {f.type.replace('_', ' ')}
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {f.score}%
+                                  </LqText>
+                                </Flex>
+                                <LqText variant="xs" color="muted">
+                                  {f.description}
+                                </LqText>
+                              </Surface>
+                            ),
+                          )}
+                        </Stack>
+                      )}
+                    </Stack>
+                  </Surface>
+
+                  <Tabs
+                    tabs={[
+                      { key: 'dashboard', label: 'Dashboard', icon: <BarChart3 size={16} /> },
+                      {
+                        key: 'entities',
+                        label: 'Entities',
+                        icon: <User size={16} />,
+                        count: analysis!.entities.length,
+                      },
+                      {
+                        key: 'patterns',
+                        label: 'Patterns',
+                        icon: <Activity size={16} />,
+                        count: analysis!.patterns.length,
+                      },
+                      {
+                        key: 'anomalies',
+                        label: 'Anomalies',
+                        icon: <ShieldAlert size={16} />,
+                        count: analysis!.anomalies.length,
+                      },
+                      { key: 'metadata', label: 'Metadata', icon: <FileText size={16} /> },
+                    ]}
+                    activeTab={activeTab}
+                    onChange={(k) =>
+                      setActiveTab(
+                        k as 'dashboard' | 'entities' | 'patterns' | 'anomalies' | 'metadata',
+                      )
+                    }
+                    className={styles.autoGen108}
+                  />
+
+                  <Box>
+                    {activeTab === 'dashboard' && (
+                      <Stack gap="xl">
+                        <Grid cols={{ sm: 1, md: 2 }} gap="md">
+                          <Surface variant="glass-highlight" p="md">
+                            <Stack gap="sm">
+                              <LqText variant="xs" weight="bold" color="muted">
+                                TECHNICAL FORENSICS
+                              </LqText>
+                              <Stack gap="xs">
+                                <Flex justify="between">
+                                  <LqText variant="xs" color="muted">
+                                    Producer
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {metrics?.technical?.producer || '—'}
+                                  </LqText>
+                                </Flex>
+                                <Flex justify="between">
+                                  <LqText variant="xs" color="muted">
+                                    Creator
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {metrics?.technical?.creator || '—'}
+                                  </LqText>
+                                </Flex>
+                                <Flex justify="between">
+                                  <LqText variant="xs" color="muted">
+                                    Created
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {metrics?.technical?.creationDate || '—'}
+                                  </LqText>
+                                </Flex>
+                                <Flex justify="between">
+                                  <LqText variant="xs" color="muted">
+                                    Pages
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {metrics?.technical?.pageCount || '—'}
+                                  </LqText>
+                                </Flex>
+                              </Stack>
+                              <Button variant="secondary" size="sm" onClick={() => {}}>
+                                <Download size={10} /> Export Signal Data
+                              </Button>
+                            </Stack>
+                          </Surface>
+
+                          <Surface variant="glass-highlight" p="md">
+                            <Stack gap="sm">
+                              <LqText variant="xs" weight="bold" color="muted">
+                                LINGUISTIC / SENTIMENT
+                              </LqText>
+                              <Stack gap="xs">
+                                <Flex justify="between">
+                                  <LqText variant="xs" color="muted">
+                                    FKGL (Readability)
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {metrics?.linguistic?.readabilityFKGL || '—'}
+                                  </LqText>
+                                </Flex>
+                                <Flex justify="between">
+                                  <LqText variant="xs" color="muted">
+                                    Sentiment
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {(metrics?.linguistic?.sentiment || 'neutral')
+                                      .charAt(0)
+                                      .toUpperCase() +
+                                      (metrics?.linguistic?.sentiment || 'neutral').slice(1)}
+                                  </LqText>
+                                </Flex>
+                                <Flex justify="between">
+                                  <LqText variant="xs" color="muted">
+                                    TTR
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {metrics?.linguistic?.typeTokenRatio || '—'}%
+                                  </LqText>
+                                </Flex>
+                                <Flex justify="between">
+                                  <LqText variant="xs" color="muted">
+                                    Risk Score
+                                  </LqText>
+                                  <LqText variant="xs" weight="bold">
+                                    {metrics?.network?.riskScore || '—'}%
+                                  </LqText>
+                                </Flex>
+                              </Stack>
+                            </Stack>
+                          </Surface>
+                        </Grid>
+
+                        <Surface variant="glass" p="md">
+                          <LqText
+                            variant="xs"
+                            weight="bold"
+                            color="muted"
+                            style={{ marginBottom: 'lg' }}
+                          >
+                            SENTIMENT DISTRIBUTION
+                          </LqText>
+                          <Box className={styles.autoGen109}>
+                            <ResponsiveContainer width="100%" height="100%">
+                              <PieChart>
+                                <Pie
+                                  data={[
+                                    { name: 'Pos', value: summary?.sentimentCounts?.positive || 0 },
+                                    { name: 'Neu', value: summary?.sentimentCounts?.neutral || 0 },
+                                    { name: 'Neg', value: summary?.sentimentCounts?.negative || 0 },
+                                  ]}
+                                  dataKey="value"
+                                  stroke="none"
+                                  outerRadius={60}
+                                  label
+                                >
+                                  {[
+                                    'var(--lq-success)',
+                                    'var(--lq-text-dim)',
+                                    'var(--lq-error)',
+                                  ].map((c, i) => (
                                     <Cell key={i} fill={c} />
-                                  ),
-                                )}
-                              </Pie>
-                              <Tooltip
-                                contentStyle={{
-                                  backgroundColor: 'var(--lq-surface-3)',
-                                  border: 'none',
-                                  borderRadius: '4px',
-                                }}
-                              />
-                            </PieChart>
-                          </ResponsiveContainer>
-                        </Box>
-                      </Surface>
+                                  ))}
+                                </Pie>
+                                <Tooltip
+                                  contentStyle={{
+                                    backgroundColor: 'var(--lq-surface-3)',
+                                    border: 'none',
+                                    borderRadius: '4px',
+                                  }}
+                                />
+                              </PieChart>
+                            </ResponsiveContainer>
+                          </Box>
+                        </Surface>
 
-                      <Stack gap="sm">
-                        <LqText variant="xs" weight="bold" color="muted">
-                          HIGH RISK CORRELATES
-                        </LqText>
-                        <Stack gap="xs">
-                          {topRisk.slice(0, 3).map((t) => (
-                            <Surface
-                              key={t.id}
-                              variant="glass-highlight"
-                              p="sm"
-                              className={styles.autoGen110}
-                              onClick={() => openForensicDocument(String(t.id))}
-                            >
-                              <Flex justify="between" align="center">
-                                <LqText variant="xs" weight="bold">
-                                  {t.fileName}
-                                </LqText>
-                                <Badge tone="danger">{`${t.score}% RISK`}</Badge>
-                              </Flex>
-                            </Surface>
-                          ))}
+                        <Stack gap="sm">
+                          <LqText variant="xs" weight="bold" color="muted">
+                            HIGH RISK CORRELATES
+                          </LqText>
+                          <Stack gap="xs">
+                            {topRisk.slice(0, 3).map((t) => (
+                              <Surface
+                                key={t.id}
+                                variant="glass-highlight"
+                                p="sm"
+                                className={styles.autoGen110}
+                                onClick={() => openForensicDocument(String(t.id))}
+                              >
+                                <Flex justify="between" align="center">
+                                  <LqText variant="xs" weight="bold">
+                                    {t.fileName}
+                                  </LqText>
+                                  <Badge tone="danger">{`${t.score}% RISK`}</Badge>
+                                </Flex>
+                              </Surface>
+                            ))}
+                          </Stack>
                         </Stack>
                       </Stack>
-                    </Stack>
-                  )}
+                    )}
 
-                  {activeTab === 'entities' && (
-                    <Stack gap="sm">
-                      {analysis!.entities.map((e: DetectedEntity, i: number) => {
-                        const IconComp = getEntityIcon(e.type);
-                        return (
+                    {activeTab === 'entities' && (
+                      <Stack gap="sm">
+                        {analysis!.entities.map((e: DetectedEntity, i: number) => {
+                          const IconComp = getEntityIcon(e.type);
+                          return (
+                            <Surface
+                              key={i}
+                              variant="glass"
+                              p="md"
+                              className={styles.autoGen111}
+                              onClick={() => setSelectedEntity(e)}
+                            >
+                              <Flex gap="md" align="center">
+                                <Box p="xs" className={styles.autoGen112}>
+                                  <IconComp size={16} className={styles.autoGen113} />
+                                </Box>
+                                <Stack gap="none" style={{ flex: 1 }}>
+                                  <Flex justify="between" align="center">
+                                    <LqText variant="small" weight="bold">
+                                      {e.text}
+                                    </LqText>
+                                    <LqText variant="xs" color="muted">
+                                      {Math.round(e.confidence * 100)}% CONF
+                                    </LqText>
+                                  </Flex>
+                                  <LqText variant="xs" color="muted" weight="bold">
+                                    {e.type.toUpperCase()}
+                                  </LqText>
+                                  <LqText variant="xs" color="muted" style={{ marginTop: 'xs' }}>
+                                    {e.context}
+                                  </LqText>
+                                </Stack>
+                              </Flex>
+                            </Surface>
+                          );
+                        })}
+                      </Stack>
+                    )}
+
+                    {activeTab === 'patterns' && (
+                      <Stack gap="sm">
+                        {analysis!.patterns.map((p: DetectedPattern, i: number) => (
                           <Surface
                             key={i}
                             variant="glass"
                             p="md"
-                            className={styles.autoGen111}
-                            onClick={() => setSelectedEntity(e)}
+                            style={{
+                              borderLeft: `4px solid ${p.significance === 'high' ? 'var(--lq-error)' : 'var(--lq-warning)'}`,
+                            }}
                           >
-                            <Flex gap="md" align="center">
-                              <Box p="xs" className={styles.autoGen112}>
-                                <IconComp size={16} className={styles.autoGen113} />
-                              </Box>
-                              <Stack gap="none" style={{ flex: 1 }}>
-                                <Flex justify="between" align="center">
-                                  <LqText variant="small" weight="bold">
-                                    {e.text}
-                                  </LqText>
-                                  <LqText variant="xs" color="muted">
-                                    {Math.round(e.confidence * 100)}% CONF
-                                  </LqText>
-                                </Flex>
-                                <LqText variant="xs" color="muted" weight="bold">
-                                  {e.type.toUpperCase()}
-                                </LqText>
-                                <LqText variant="xs" color="muted" style={{ marginTop: 'xs' }}>
-                                  {e.context}
-                                </LqText>
-                              </Stack>
-                            </Flex>
-                          </Surface>
-                        );
-                      })}
-                    </Stack>
-                  )}
-
-                  {activeTab === 'patterns' && (
-                    <Stack gap="sm">
-                      {analysis!.patterns.map((p: DetectedPattern, i: number) => (
-                        <Surface
-                          key={i}
-                          variant="glass"
-                          p="md"
-                          style={{
-                            borderLeft: `4px solid ${p.significance === 'high' ? 'var(--lq-error)' : 'var(--lq-warning)'}`,
-                          }}
-                        >
-                          <Stack gap="xs">
-                            <Flex justify="between">
-                              <Badge
-                                tone={p.significance === 'high' ? 'danger' : 'warning'}
-                              >{`${p.type.toUpperCase()} PATTERN`}</Badge>
-                              <LqText variant="xs" color="muted">
-                                SIG: {p.significance.toUpperCase()}
-                              </LqText>
-                            </Flex>
-                            <LqText variant="small" weight="bold">
-                              {p.description}
-                            </LqText>
-                            <LqText variant="xs" color="muted">
-                              Involves: {p.entities.join(', ')}
-                            </LqText>
-                          </Stack>
-                        </Surface>
-                      ))}
-                    </Stack>
-                  )}
-
-                  {activeTab === 'anomalies' && (
-                    <Stack gap="sm">
-                      {analysis!.anomalies.map((a: DetectedAnomaly, i: number) => (
-                        <Surface
-                          key={i}
-                          variant="glass"
-                          p="md"
-                          className={cn(
-                            'border-l-4',
-                            a.severity === 'critical'
-                              ? 'border-l-[var(--lq-error)]'
-                              : 'border-l-[var(--lq-accent)]',
-                          )}
-                        >
-                          <Stack gap="xs">
-                            <Flex justify="between">
-                              <Badge
-                                tone={a.severity === 'critical' ? 'danger' : 'accent'}
-                              >{`${a.type.toUpperCase()} ANOMALY`}</Badge>
-                              <LqText variant="xs" color="muted">
-                                {a.severity.toUpperCase()}
-                              </LqText>
-                            </Flex>
-                            <LqText variant="small" weight="bold">
-                              {a.description}
-                            </LqText>
-                            <LqText variant="xs" color="muted">
-                              {a.explanation}
-                            </LqText>
-                            {a.requiresInvestigation && (
-                              <Flex align="center" gap="xs" mt="xs" className={styles.autoGen114}>
-                                <AlertTriangle size={12} />
-                                <LqText variant="xs" weight="bold">
-                                  REQUIRES IMMEDIATE INVESTIGATION
+                            <Stack gap="xs">
+                              <Flex justify="between">
+                                <Badge
+                                  tone={p.significance === 'high' ? 'danger' : 'warning'}
+                                >{`${p.type.toUpperCase()} PATTERN`}</Badge>
+                                <LqText variant="xs" color="muted">
+                                  SIG: {p.significance.toUpperCase()}
                                 </LqText>
                               </Flex>
-                            )}
-                          </Stack>
-                        </Surface>
-                      ))}
-                    </Stack>
-                  )}
+                              <LqText variant="small" weight="bold">
+                                {p.description}
+                              </LqText>
+                              <LqText variant="xs" color="muted">
+                                Involves: {p.entities.join(', ')}
+                              </LqText>
+                            </Stack>
+                          </Surface>
+                        ))}
+                      </Stack>
+                    )}
 
-                  {activeTab === 'metadata' && (
-                    <DocumentMetadataPanel
-                      document={{
-                        id: documentId,
-                        metadata: {
-                          technical: metrics?.technical || analysis!.metadata!.technical,
-                          structure: metrics?.structural || analysis!.metadata!.structure,
-                          linguistics: metrics?.linguistic || analysis!.metadata!.linguistics,
-                          network: metrics?.network || analysis!.metadata!.network,
-                          tags: analysis!.metadata!.tags,
-                        },
-                      }}
-                    />
-                  )}
-                </Box>
-              </Stack>
-            )}
-          </Surface>
-        </Box>
+                    {activeTab === 'anomalies' && (
+                      <Stack gap="sm">
+                        {analysis!.anomalies.map((a: DetectedAnomaly, i: number) => (
+                          <Surface
+                            key={i}
+                            variant="glass"
+                            p="md"
+                            className={cn(
+                              'border-l-4',
+                              a.severity === 'critical'
+                                ? 'border-l-[var(--lq-error)]'
+                                : 'border-l-[var(--lq-accent)]',
+                            )}
+                          >
+                            <Stack gap="xs">
+                              <Flex justify="between">
+                                <Badge
+                                  tone={a.severity === 'critical' ? 'danger' : 'accent'}
+                                >{`${a.type.toUpperCase()} ANOMALY`}</Badge>
+                                <LqText variant="xs" color="muted">
+                                  {a.severity.toUpperCase()}
+                                </LqText>
+                              </Flex>
+                              <LqText variant="small" weight="bold">
+                                {a.description}
+                              </LqText>
+                              <LqText variant="xs" color="muted">
+                                {a.explanation}
+                              </LqText>
+                              {a.requiresInvestigation && (
+                                <Flex align="center" gap="xs" mt="xs" className={styles.autoGen114}>
+                                  <AlertTriangle size={12} />
+                                  <LqText variant="xs" weight="bold">
+                                    REQUIRES IMMEDIATE INVESTIGATION
+                                  </LqText>
+                                </Flex>
+                              )}
+                            </Stack>
+                          </Surface>
+                        ))}
+                      </Stack>
+                    )}
+
+                    {activeTab === 'metadata' && (
+                      <DocumentMetadataPanel
+                        document={{
+                          id: documentId,
+                          metadata: {
+                            technical: metrics?.technical || analysis!.metadata!.technical,
+                            structure: metrics?.structural || analysis!.metadata!.structure,
+                            linguistics: metrics?.linguistic || analysis!.metadata!.linguistics,
+                            network: metrics?.network || analysis!.metadata!.network,
+                            tags: analysis!.metadata!.tags,
+                          },
+                        }}
+                      />
+                    )}
+                  </Box>
+                </Stack>
+              )}
+            </Surface>
+          </Box>
+        )}
       </Flex>
 
       {/* Entity Detail Overlay */}

--- a/src/client/components/investigation/ForensicReportGenerator.tsx
+++ b/src/client/components/investigation/ForensicReportGenerator.tsx
@@ -49,6 +49,7 @@ interface GeneratedReport {
 
 interface ForensicReportGeneratorProps {
   investigationId?: number;
+  mobileMode?: boolean;
 }
 
 const DEFAULT_TEMPLATES: ReportTemplate[] = [
@@ -96,6 +97,7 @@ const DEFAULT_TEMPLATES: ReportTemplate[] = [
 
 export default function ForensicReportGenerator({
   investigationId,
+  mobileMode,
 }: ForensicReportGeneratorProps = {}) {
   const [templates] = useState<ReportTemplate[]>(DEFAULT_TEMPLATES);
   const [selectedTemplate, setSelectedTemplate] = useState<string>('legal-prosecution');
@@ -213,157 +215,159 @@ export default function ForensicReportGenerator({
 
   return (
     <Box className={styles.autoGen117} style={{ backgroundColor: 'var(--lq-surface-1)' }}>
-      <Surface variant="glass" p="xl" className={styles.autoGen118}>
-        <Stack gap="lg">
-          <Flex justify="between" align="center">
-            <Stack gap="none">
-              <Flex align="center" gap="md">
-                <FileText size={24} className={styles.autoGen119} />
-                <LqText variant="h1" weight="bold">
-                  Intelligence Briefing Generator
-                </LqText>
-              </Flex>
-              <LqText
-                variant="small"
-                color="muted"
-                weight="bold"
-                style={{ textTransform: 'uppercase', marginTop: 'var(--spacing-xs)' }}
-              >
-                Process Sigma • Automated Narrative Construction
-              </LqText>
-            </Stack>
-            <Flex gap="md">
-              <Button variant="ghost" size="sm">
-                <Shield size={14} className="mr-1" /> SECURE MODE
-              </Button>
-              <Button variant="ghost" size="sm" onClick={() => window.print()}>
-                <Printer size={14} />
-              </Button>
-            </Flex>
-          </Flex>
-
-          <Surface variant="glass-highlight" p="lg" className={styles.autoGen120}>
-            <Grid cols={2} gap="xl">
-              <Stack gap="md">
-                <Stack gap="xs">
-                  <LqText variant="xs" weight="bold" color="muted">
-                    REPORT DESIGNATION
+      {!mobileMode && (
+        <Surface variant="glass" p="xl" className={styles.autoGen118}>
+          <Stack gap="lg">
+            <Flex justify="between" align="center">
+              <Stack gap="none">
+                <Flex align="center" gap="md">
+                  <FileText size={24} className={styles.autoGen119} />
+                  <LqText variant="h1" weight="bold">
+                    Intelligence Briefing Generator
                   </LqText>
-                  <input
-                    style={{
-                      width: '100%',
-                      background: 'var(--lq-surface-3)',
-                      border: '1px solid var(--lq-surface-4)',
-                      borderRadius: '0.375rem',
-                      padding: '0.5rem 0.75rem',
-                      fontSize: '0.875rem',
-                      color: 'var(--lq-text-primary)',
-                      outline: 'none',
-                    }}
-                    value={reportTitle}
-                    onChange={(e) => setReportTitle(e.target.value)}
-                    placeholder="Case ID / Mission Title..."
-                  />
-                </Stack>
-                <Grid cols={2} gap="md">
-                  <Stack gap="xs">
-                    <LqText variant="xs" weight="bold" color="muted">
-                      TEMPLATE LENS
-                    </LqText>
-                    <select
-                      style={{
-                        width: '100%',
-                        background: 'var(--lq-surface-3)',
-                        border: '1px solid var(--lq-surface-4)',
-                        borderRadius: '0.375rem',
-                        padding: '0.5rem 0.75rem',
-                        fontSize: '0.875rem',
-                        color: 'var(--lq-text-primary)',
-                        outline: 'none',
-                      }}
-                      value={selectedTemplate}
-                      onChange={(e) => setSelectedTemplate(e.target.value)}
-                    >
-                      {templates.map((t) => (
-                        <option key={t.id} value={t.id}>
-                          {t.name}
-                        </option>
-                      ))}
-                    </select>
-                  </Stack>
-                  <Stack gap="xs">
-                    <LqText variant="xs" weight="bold" color="muted">
-                      CLASSIFICATION LEVEL
-                    </LqText>
-                    <select
-                      style={{
-                        width: '100%',
-                        background: 'var(--lq-surface-3)',
-                        border: '1px solid var(--lq-surface-4)',
-                        borderRadius: '0.375rem',
-                        padding: '0.5rem 0.75rem',
-                        fontSize: '0.875rem',
-                        color: 'var(--lq-text-primary)',
-                        outline: 'none',
-                      }}
-                      value={classification}
-                      onChange={(e) => setClassification(e.target.value)}
-                    >
-                      {['unclassified', 'confidential', 'restricted', 'secret'].map((c) => (
-                        <option key={c} value={c}>
-                          {c.toUpperCase()}
-                        </option>
-                      ))}
-                    </select>
-                  </Stack>
-                </Grid>
-              </Stack>
-              <Stack gap="md">
-                <Flex gap="md" py="xs">
-                  <label className={styles.autoGen121}>
-                    <input
-                      type="checkbox"
-                      checked={includeEvidence}
-                      onChange={(e) => setIncludeEvidence(e.target.checked)}
-                    />
-                    <LqText variant="xs" weight="bold">
-                      ATTACH CHAIN OF CUSTODY
-                    </LqText>
-                  </label>
-                  <label className={styles.autoGen122}>
-                    <input
-                      type="checkbox"
-                      checked={includeCharts}
-                      onChange={(e) => setIncludeCharts(e.target.checked)}
-                    />
-                    <LqText variant="xs" weight="bold">
-                      INJECT ANALYTICAL CHARTS
-                    </LqText>
-                  </label>
                 </Flex>
-                <Button variant="secondary" onClick={generateReport} disabled={isGenerating}>
-                  {isGenerating ? (
-                    <Loader2 className="animate-spin mr-2" size={16} />
-                  ) : (
-                    <Zap className="mr-2" size={16} />
-                  )}
-                  {isGenerating
-                    ? `Synthesizing Intelligence... ${generationProgress}%`
-                    : 'Execute Narrative Extraction'}
-                </Button>
-                {isGenerating && (
-                  <Box className={styles.autoGen123}>
-                    <Box
-                      className={styles.autoGen124}
-                      style={{ width: `${generationProgress}%` }}
-                    />
-                  </Box>
-                )}
+                <LqText
+                  variant="small"
+                  color="muted"
+                  weight="bold"
+                  style={{ textTransform: 'uppercase', marginTop: 'var(--spacing-xs)' }}
+                >
+                  Process Sigma • Automated Narrative Construction
+                </LqText>
               </Stack>
-            </Grid>
-          </Surface>
-        </Stack>
-      </Surface>
+              <Flex gap="md">
+                <Button variant="ghost" size="sm">
+                  <Shield size={14} className="mr-1" /> SECURE MODE
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => window.print()}>
+                  <Printer size={14} />
+                </Button>
+              </Flex>
+            </Flex>
+
+            <Surface variant="glass-highlight" p="lg" className={styles.autoGen120}>
+              <Grid cols={2} gap="xl">
+                <Stack gap="md">
+                  <Stack gap="xs">
+                    <LqText variant="xs" weight="bold" color="muted">
+                      REPORT DESIGNATION
+                    </LqText>
+                    <input
+                      style={{
+                        width: '100%',
+                        background: 'var(--lq-surface-3)',
+                        border: '1px solid var(--lq-surface-4)',
+                        borderRadius: '0.375rem',
+                        padding: '0.5rem 0.75rem',
+                        fontSize: '0.875rem',
+                        color: 'var(--lq-text-primary)',
+                        outline: 'none',
+                      }}
+                      value={reportTitle}
+                      onChange={(e) => setReportTitle(e.target.value)}
+                      placeholder="Case ID / Mission Title..."
+                    />
+                  </Stack>
+                  <Grid cols={2} gap="md">
+                    <Stack gap="xs">
+                      <LqText variant="xs" weight="bold" color="muted">
+                        TEMPLATE LENS
+                      </LqText>
+                      <select
+                        style={{
+                          width: '100%',
+                          background: 'var(--lq-surface-3)',
+                          border: '1px solid var(--lq-surface-4)',
+                          borderRadius: '0.375rem',
+                          padding: '0.5rem 0.75rem',
+                          fontSize: '0.875rem',
+                          color: 'var(--lq-text-primary)',
+                          outline: 'none',
+                        }}
+                        value={selectedTemplate}
+                        onChange={(e) => setSelectedTemplate(e.target.value)}
+                      >
+                        {templates.map((t) => (
+                          <option key={t.id} value={t.id}>
+                            {t.name}
+                          </option>
+                        ))}
+                      </select>
+                    </Stack>
+                    <Stack gap="xs">
+                      <LqText variant="xs" weight="bold" color="muted">
+                        CLASSIFICATION LEVEL
+                      </LqText>
+                      <select
+                        style={{
+                          width: '100%',
+                          background: 'var(--lq-surface-3)',
+                          border: '1px solid var(--lq-surface-4)',
+                          borderRadius: '0.375rem',
+                          padding: '0.5rem 0.75rem',
+                          fontSize: '0.875rem',
+                          color: 'var(--lq-text-primary)',
+                          outline: 'none',
+                        }}
+                        value={classification}
+                        onChange={(e) => setClassification(e.target.value)}
+                      >
+                        {['unclassified', 'confidential', 'restricted', 'secret'].map((c) => (
+                          <option key={c} value={c}>
+                            {c.toUpperCase()}
+                          </option>
+                        ))}
+                      </select>
+                    </Stack>
+                  </Grid>
+                </Stack>
+                <Stack gap="md">
+                  <Flex gap="md" py="xs">
+                    <label className={styles.autoGen121}>
+                      <input
+                        type="checkbox"
+                        checked={includeEvidence}
+                        onChange={(e) => setIncludeEvidence(e.target.checked)}
+                      />
+                      <LqText variant="xs" weight="bold">
+                        ATTACH CHAIN OF CUSTODY
+                      </LqText>
+                    </label>
+                    <label className={styles.autoGen122}>
+                      <input
+                        type="checkbox"
+                        checked={includeCharts}
+                        onChange={(e) => setIncludeCharts(e.target.checked)}
+                      />
+                      <LqText variant="xs" weight="bold">
+                        INJECT ANALYTICAL CHARTS
+                      </LqText>
+                    </label>
+                  </Flex>
+                  <Button variant="secondary" onClick={generateReport} disabled={isGenerating}>
+                    {isGenerating ? (
+                      <Loader2 className="animate-spin mr-2" size={16} />
+                    ) : (
+                      <Zap className="mr-2" size={16} />
+                    )}
+                    {isGenerating
+                      ? `Synthesizing Intelligence... ${generationProgress}%`
+                      : 'Execute Narrative Extraction'}
+                  </Button>
+                  {isGenerating && (
+                    <Box className={styles.autoGen123}>
+                      <Box
+                        className={styles.autoGen124}
+                        style={{ width: `${generationProgress}%` }}
+                      />
+                    </Box>
+                  )}
+                </Stack>
+              </Grid>
+            </Surface>
+          </Stack>
+        </Surface>
+      )}
 
       <Box p="xl">
         {!generatedReport && !isGenerating ? (

--- a/src/client/components/investigation/HypothesisTestingFramework.tsx
+++ b/src/client/components/investigation/HypothesisTestingFramework.tsx
@@ -71,6 +71,7 @@ interface HypothesisTestingFrameworkProps {
   initialHypothesis?: string;
   evidenceItems: EvidenceItem[];
   onHypothesesUpdate: (hypotheses: Hypothesis[]) => void;
+  mobileMode?: boolean;
 }
 
 const parseDate = (value: unknown): Date =>
@@ -93,6 +94,7 @@ export const HypothesisTestingFramework: React.FC<HypothesisTestingFrameworkProp
   initialHypothesis = '',
   evidenceItems,
   onHypothesesUpdate,
+  mobileMode,
 }) => {
   const [hypotheses, setHypotheses] = useState<Hypothesis[]>([]);
   const [activeHypothesis, setActiveHypothesis] = useState<Hypothesis | null>(null);
@@ -246,24 +248,26 @@ export const HypothesisTestingFramework: React.FC<HypothesisTestingFrameworkProp
   return (
     <Box style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
       {/* Header */}
-      <Surface variant="glass" p="xl" className={styles.autoGen132}>
-        <Flex justify="between" align="center">
-          <Stack gap="none">
-            <Flex align="center" gap="md">
-              <Target size={24} className={styles.autoGen133} />
-              <LqText variant="h1" weight="bold">
-                Hypothesis Testing Workbench
+      {!mobileMode && (
+        <Surface variant="glass" p="xl" className={styles.autoGen132}>
+          <Flex justify="between" align="center">
+            <Stack gap="none">
+              <Flex align="center" gap="md">
+                <Target size={24} className={styles.autoGen133} />
+                <LqText variant="h1" weight="bold">
+                  Hypothesis Testing Workbench
+                </LqText>
+              </Flex>
+              <LqText variant="xs" color="muted" weight="bold" style={{ marginTop: 'xs' }}>
+                Systematic Theory Analysis • Analytical Confidence Scoring
               </LqText>
-            </Flex>
-            <LqText variant="xs" color="muted" weight="bold" style={{ marginTop: 'xs' }}>
-              Systematic Theory Analysis • Analytical Confidence Scoring
-            </LqText>
-          </Stack>
-          <Button variant="secondary" size="sm" onClick={() => setShowNewForm(true)}>
-            <Plus size={16} /> <span style={{ marginLeft: '0.5rem' }}>Initialize Theory</span>
-          </Button>
-        </Flex>
-      </Surface>
+            </Stack>
+            <Button variant="secondary" size="sm" onClick={() => setShowNewForm(true)}>
+              <Plus size={16} /> <span style={{ marginLeft: '0.5rem' }}>Initialize Theory</span>
+            </Button>
+          </Flex>
+        </Surface>
+      )}
 
       <Box p="xl">
         <Stack gap="xl">

--- a/src/client/components/investigation/InvestigationWorkspace.tsx
+++ b/src/client/components/investigation/InvestigationWorkspace.tsx
@@ -65,6 +65,8 @@ import { EvidenceModal } from '../common/EvidenceModal';
 import { useToasts } from '../common/useToasts';
 import { useInvestigationOnboarding } from '../../hooks/useInvestigationOnboarding';
 import { useScrollLock } from '../../hooks/useScrollLock';
+import { useIsMobile } from '../../hooks/useIsMobile';
+import { MobileInvestigationShell } from './mobile/MobileInvestigationShell';
 import { InvestigationOnboarding } from './InvestigationOnboarding';
 import { NetworkVisualization } from '../visualizations/NetworkVisualization';
 
@@ -144,6 +146,7 @@ export const InvestigationWorkspace: React.FC<InvestigationWorkspaceProps> = ({
   const location = useLocation();
   const navigate = useNavigate();
   const { addToast } = useToasts();
+  const isMobile = useIsMobile();
   const [showImportModal, setShowImportModal] = useState(false);
 
   const {
@@ -747,8 +750,20 @@ export const InvestigationWorkspace: React.FC<InvestigationWorkspaceProps> = ({
         </Box>
       )}
 
+      {/* Investigation Workspace Layout (Mobile) */}
+      {selectedInvestigation && isMobile && (
+        <MobileInvestigationShell
+          currentUser={currentUser}
+          selectedInvestigation={selectedInvestigation}
+          timelineEvents={timelineEvents}
+          evidenceItems={evidenceItems}
+          investigationId={String(selectedInvestigation.id)}
+          onInvestigationSelect={onInvestigationSelect}
+        />
+      )}
+
       {/* Investigation Workspace Layout (Restored Flex) */}
-      {selectedInvestigation && (
+      {selectedInvestigation && !isMobile && (
         <Flex grow fullWidth className={styles.layoutContainer}>
           {/* Dashboard Sidebar (Fixed Width) */}
           <Box className={styles.desktopSidebar} w="320px">

--- a/src/client/components/investigation/MultiSourceCorrelationEngine.tsx
+++ b/src/client/components/investigation/MultiSourceCorrelationEngine.tsx
@@ -73,7 +73,13 @@ interface CorrelationRule {
   triggerCount: number;
 }
 
-export const MultiSourceCorrelationEngine = () => {
+interface MultiSourceCorrelationEngineProps {
+  mobileMode?: boolean;
+}
+
+export const MultiSourceCorrelationEngine = ({
+  mobileMode,
+}: MultiSourceCorrelationEngineProps = {}) => {
   const [dataSources, setDataSources] = useState<DataSource[]>([]);
   const [correlations, setCorrelations] = useState<CorrelationResult[]>([]);
   const [_correlationRules, setCorrelationRules] = useState<CorrelationRule[]>([]);
@@ -182,134 +188,136 @@ export const MultiSourceCorrelationEngine = () => {
     <Box className={styles.autoGen307} style={{ backgroundColor: 'var(--lq-surface-1)' }}>
       <Stack gap="xl" className={styles.autoGen308}>
         {/* Header HUD */}
-        <Surface variant="glass" p="xl" className={styles.autoGen309}>
-          <Flex justify="between" align="start">
-            <Stack gap="none">
-              <Flex align="center" gap="md">
-                <Layers size={24} className={styles.autoGen310} />
-                <LqText variant="h1" weight="bold">
-                  Multi-Source Correlation Engine
+        {!mobileMode && (
+          <Surface variant="glass" p="xl" className={styles.autoGen309}>
+            <Flex justify="between" align="start">
+              <Stack gap="none">
+                <Flex align="center" gap="md">
+                  <Layers size={24} className={styles.autoGen310} />
+                  <LqText variant="h1" weight="bold">
+                    Multi-Source Correlation Engine
+                  </LqText>
+                </Flex>
+                <LqText
+                  variant="xs"
+                  color="muted"
+                  weight="bold"
+                  style={{ textTransform: 'uppercase' }}
+                  mt="xs"
+                >
+                  Neural Cross-Reference • Forensic Pattern Derivation
                 </LqText>
+              </Stack>
+              <Flex gap="md">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={exportCorrelations}
+                  className={styles.autoGen311}
+                >
+                  <Download size={14} className="mr-2" /> Export Analysis
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={recomputeCorrelations}
+                  disabled={isAnalyzing}
+                >
+                  {isAnalyzing ? (
+                    <Loader2 size={14} className="animate-spin mr-2" />
+                  ) : (
+                    <Zap size={14} className="mr-2" />
+                  )}
+                  {isAnalyzing ? `Analyzing Signals (${analysisProgress}%)` : 'Execute Analysis'}
+                </Button>
               </Flex>
-              <LqText
-                variant="xs"
-                color="muted"
-                weight="bold"
-                style={{ textTransform: 'uppercase' }}
-                mt="xs"
-              >
-                Neural Cross-Reference • Forensic Pattern Derivation
-              </LqText>
-            </Stack>
-            <Flex gap="md">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={exportCorrelations}
-                className={styles.autoGen311}
-              >
-                <Download size={14} className="mr-2" /> Export Analysis
-              </Button>
-              <Button
-                variant="secondary"
-                size="sm"
-                onClick={recomputeCorrelations}
-                disabled={isAnalyzing}
-              >
-                {isAnalyzing ? (
-                  <Loader2 size={14} className="animate-spin mr-2" />
-                ) : (
-                  <Zap size={14} className="mr-2" />
-                )}
-                {isAnalyzing ? `Analyzing Signals (${analysisProgress}%)` : 'Execute Analysis'}
-              </Button>
             </Flex>
-          </Flex>
 
-          {/* Search/Filter HUD */}
-          <Box mt="xl" pt="xl" className={styles.autoGen312}>
-            <Grid cols={4} gap="lg" align="end">
-              <Stack gap="xs">
-                <LqText variant="xs" weight="bold" color="muted">
-                  SIGNAL SEARCH
-                </LqText>
-                <Box className={styles.autoGen313}>
-                  <Search size={14} className={styles.autoGen314} />
-                  <input
+            {/* Search/Filter HUD */}
+            <Box mt="xl" pt="xl" className={styles.autoGen312}>
+              <Grid cols={4} gap="lg" align="end">
+                <Stack gap="xs">
+                  <LqText variant="xs" weight="bold" color="muted">
+                    SIGNAL SEARCH
+                  </LqText>
+                  <Box className={styles.autoGen313}>
+                    <Search size={14} className={styles.autoGen314} />
+                    <input
+                      style={{
+                        width: '100%',
+                        background: 'var(--lq-surface-3)',
+                        border: '1px solid var(--lq-surface-4)',
+                        borderRadius: '0.375rem',
+                        padding: '0.5rem 0.75rem 0.5rem 2.5rem',
+                        fontSize: '0.875rem',
+                        color: 'var(--lq-text-primary)',
+                        outline: 'none',
+                      }}
+                      value={searchTerm}
+                      onChange={(e) => setSearchTerm(e.target.value)}
+                      placeholder="Filter entities..."
+                    />
+                  </Box>
+                </Stack>
+                <Stack gap="xs">
+                  <LqText variant="xs" weight="bold" color="muted">
+                    CORRELATION TYPE
+                  </LqText>
+                  <select
                     style={{
                       width: '100%',
                       background: 'var(--lq-surface-3)',
                       border: '1px solid var(--lq-surface-4)',
                       borderRadius: '0.375rem',
-                      padding: '0.5rem 0.75rem 0.5rem 2.5rem',
+                      padding: '0.5rem 0.75rem',
                       fontSize: '0.875rem',
                       color: 'var(--lq-text-primary)',
                       outline: 'none',
                     }}
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    placeholder="Filter entities..."
-                  />
-                </Box>
-              </Stack>
-              <Stack gap="xs">
-                <LqText variant="xs" weight="bold" color="muted">
-                  CORRELATION TYPE
-                </LqText>
-                <select
-                  style={{
-                    width: '100%',
-                    background: 'var(--lq-surface-3)',
-                    border: '1px solid var(--lq-surface-4)',
-                    borderRadius: '0.375rem',
-                    padding: '0.5rem 0.75rem',
-                    fontSize: '0.875rem',
-                    color: 'var(--lq-text-primary)',
-                    outline: 'none',
-                  }}
-                  value={filterType}
-                  onChange={(e) => setFilterType(e.target.value)}
-                >
-                  <option value="all">All Modalities</option>
-                  <option value="temporal">Temporal</option>
-                  <option value="spatial">Spatial</option>
-                  <option value="entity">Entity</option>
-                  <option value="financial">Financial</option>
-                </select>
-              </Stack>
-              <Stack gap="xs">
-                <LqText variant="xs" weight="bold" color="muted">
-                  SIGNIFICANCE SCALE
-                </LqText>
-                <select
-                  style={{
-                    width: '100%',
-                    background: 'var(--lq-surface-3)',
-                    border: '1px solid var(--lq-surface-4)',
-                    borderRadius: '0.375rem',
-                    padding: '0.5rem 0.75rem',
-                    fontSize: '0.875rem',
-                    color: 'var(--lq-text-primary)',
-                    outline: 'none',
-                  }}
-                  value={filterSignificance}
-                  onChange={(e) => setFilterSignificance(e.target.value)}
-                >
-                  <option value="all">All Significance</option>
-                  <option value="critical">Critical</option>
-                  <option value="high">High</option>
-                  <option value="medium">Medium</option>
-                </select>
-              </Stack>
-              <Flex gap="md" align="center" className={styles.autoGen315}>
-                <Activity size={14} className={styles.autoGen316} />
-                <LqText variant="xs" weight="bold" color="muted">
-                  {filteredCorrelations.length} Intersections Extracted
-                </LqText>
-              </Flex>
-            </Grid>
-          </Box>
-        </Surface>
+                    value={filterType}
+                    onChange={(e) => setFilterType(e.target.value)}
+                  >
+                    <option value="all">All Modalities</option>
+                    <option value="temporal">Temporal</option>
+                    <option value="spatial">Spatial</option>
+                    <option value="entity">Entity</option>
+                    <option value="financial">Financial</option>
+                  </select>
+                </Stack>
+                <Stack gap="xs">
+                  <LqText variant="xs" weight="bold" color="muted">
+                    SIGNIFICANCE SCALE
+                  </LqText>
+                  <select
+                    style={{
+                      width: '100%',
+                      background: 'var(--lq-surface-3)',
+                      border: '1px solid var(--lq-surface-4)',
+                      borderRadius: '0.375rem',
+                      padding: '0.5rem 0.75rem',
+                      fontSize: '0.875rem',
+                      color: 'var(--lq-text-primary)',
+                      outline: 'none',
+                    }}
+                    value={filterSignificance}
+                    onChange={(e) => setFilterSignificance(e.target.value)}
+                  >
+                    <option value="all">All Significance</option>
+                    <option value="critical">Critical</option>
+                    <option value="high">High</option>
+                    <option value="medium">Medium</option>
+                  </select>
+                </Stack>
+                <Flex gap="md" align="center" className={styles.autoGen315}>
+                  <Activity size={14} className={styles.autoGen316} />
+                  <LqText variant="xs" weight="bold" color="muted">
+                    {filteredCorrelations.length} Intersections Extracted
+                  </LqText>
+                </Flex>
+              </Grid>
+            </Box>
+          </Surface>
+        )}
 
         {/* Global Metrics HUD */}
         <Grid cols={4} gap="lg">

--- a/src/client/components/investigation/mobile/EvidenceCaptureSheet.module.css
+++ b/src/client/components/investigation/mobile/EvidenceCaptureSheet.module.css
@@ -16,6 +16,9 @@
   flex-direction: column;
   overflow: hidden;
   touch-action: none;
+  --sheet-translate: 0px;
+  transform: translateY(var(--sheet-translate));
+  transition: none;
 }
 
 .dragHandle {

--- a/src/client/components/investigation/mobile/EvidenceCaptureSheet.module.css
+++ b/src/client/components/investigation/mobile/EvidenceCaptureSheet.module.css
@@ -257,3 +257,9 @@
   flex-direction: column;
   gap: 0.375rem;
 }
+
+.errorMsg {
+  color: var(--accent-red);
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}

--- a/src/client/components/investigation/mobile/EvidenceCaptureSheet.module.css
+++ b/src/client/components/investigation/mobile/EvidenceCaptureSheet.module.css
@@ -1,0 +1,256 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 200;
+  display: flex;
+  align-items: flex-end;
+}
+
+.sheet {
+  width: 100%;
+  max-height: 92vh;
+  background: var(--glass-bg-strong);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  touch-action: none;
+}
+
+.dragHandle {
+  width: 36px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 2px;
+  margin: 0.75rem auto 0;
+  flex-shrink: 0;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem 0;
+  flex-shrink: 0;
+}
+
+.title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.closeBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+}
+
+.modeTabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem 0;
+  flex-shrink: 0;
+}
+
+.modeTab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.5rem;
+  border-radius: var(--radius-base);
+  border: 1px solid var(--glass-border);
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 2.75rem;
+}
+
+.modeTabActive {
+  background: var(--glass-bg-highlight);
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+.body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.textarea {
+  width: 100%;
+  min-height: 140px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  line-height: 1.6;
+  padding: 0.75rem;
+  resize: none;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.urlNoteTextarea {
+  min-height: 80px;
+}
+
+.fileZone {
+  border: 2px dashed var(--glass-border);
+  border-radius: var(--radius-base);
+  padding: 2rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  min-height: 2.75rem;
+  background: none;
+  font-family: inherit;
+  font-size: 0.875rem;
+}
+
+.fileZoneSelected {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.fileInput {
+  display: none;
+}
+
+.urlInput {
+  width: 100%;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+}
+
+.urlInput:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.select {
+  width: 100%;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+
+.autocompleteInput {
+  width: 100%;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+}
+
+.autocompleteInput:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.suggestions {
+  background: var(--glass-bg-strong);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  overflow: hidden;
+}
+
+.suggestionRow {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  text-align: left;
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+}
+
+.suggestionRow:hover {
+  background: var(--glass-bg-highlight);
+}
+
+.charCount {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: right;
+}
+
+.footer {
+  padding: 1rem;
+  padding-bottom: calc(1rem + env(safe-area-inset-bottom));
+  flex-shrink: 0;
+  border-top: 1px solid var(--glass-border);
+}
+
+.saveBtn {
+  width: 100%;
+  padding: 0.875rem;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-base);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  min-height: 2.75rem;
+}
+
+.saveBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}

--- a/src/client/components/investigation/mobile/EvidenceCaptureSheet.tsx
+++ b/src/client/components/investigation/mobile/EvidenceCaptureSheet.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { X, FileText, Paperclip, Link } from 'lucide-react';
 import { investigationsApi } from '../../../domains/investigations';
 import { useSubjectsQuery } from '../../../hooks/useSubjectsQuery';
+import { useToasts } from '../../common/useToasts';
 import styles from './EvidenceCaptureSheet.module.css';
 
 type CaptureMode = 'note' | 'file' | 'url';
@@ -26,6 +27,69 @@ interface EvidenceCaptureSheetProps {
   onSaved: (evidenceId: string) => void;
 }
 
+// ---------------------------------------------------------------------------
+// PersonAutocomplete — co-located sub-component
+// ---------------------------------------------------------------------------
+
+interface PersonAutocompleteProps {
+  onSelect: (id: string, name: string) => void;
+}
+
+function PersonAutocomplete({ onSelect }: PersonAutocompleteProps) {
+  const [personSearch, setPersonSearch] = useState('');
+  const [debouncedPersonSearch, setDebouncedPersonSearch] = useState('');
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedPersonSearch(personSearch), 300);
+    return () => clearTimeout(timer);
+  }, [personSearch]);
+
+  const { data: subjectsData } = useSubjectsQuery({
+    page: 1,
+    pageSize: 5,
+    searchTerm: debouncedPersonSearch,
+    entityType: 'all',
+    sortBy: 'name',
+    sortOrder: 'asc',
+    selectedRiskLevel: null,
+  });
+
+  const subjects = subjectsData?.subjects ?? [];
+  const showSuggestions = personSearch.length > 0 && subjects.length > 0;
+
+  return (
+    <>
+      <input
+        type="text"
+        className={styles.autocompleteInput}
+        placeholder="Search subjects…"
+        value={personSearch}
+        onChange={(e) => setPersonSearch(e.target.value)}
+      />
+      {showSuggestions && (
+        <div className={styles.suggestions}>
+          {subjects.map((s) => (
+            <button
+              key={s.id}
+              className={styles.suggestionRow}
+              onClick={() => {
+                onSelect(String(s.id), s.name);
+                setPersonSearch('');
+              }}
+            >
+              {s.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// EvidenceCaptureSheet
+// ---------------------------------------------------------------------------
+
 export function EvidenceCaptureSheet({
   investigationId,
   onClose,
@@ -37,27 +101,17 @@ export function EvidenceCaptureSheet({
   const [urlNote, setUrlNote] = useState('');
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [evidenceType, setEvidenceType] = useState('Auto');
-  const [personSearch, setPersonSearch] = useState('');
   const [taggedPersonId, setTaggedPersonId] = useState<string | null>(null);
   const [taggedPersonName, setTaggedPersonName] = useState('');
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const { addToast } = useToasts();
 
   const sheetRef = useRef<HTMLDivElement>(null);
   const touchStartY = useRef(0);
   const touchDeltaY = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
-
-  const { data: subjectsData } = useSubjectsQuery({
-    page: 1,
-    pageSize: 10,
-    searchTerm: personSearch,
-    entityType: 'all',
-    sortBy: 'name',
-    sortOrder: 'asc',
-    selectedRiskLevel: null,
-  });
-
-  const subjects = subjectsData?.subjects ?? [];
 
   const isContentReady =
     (mode === 'note' && noteText.trim().length > 0) ||
@@ -86,6 +140,7 @@ export function EvidenceCaptureSheet({
 
   const handleSave = useCallback(async () => {
     if (!isContentReady || saving) return;
+    setSaveError(null);
     setSaving(true);
     try {
       let payload: Record<string, unknown>;
@@ -94,6 +149,7 @@ export function EvidenceCaptureSheet({
           title: noteText.slice(0, 80),
           description: noteText,
           type: 'note',
+          status: 'unsorted',
           evidence_type: evidenceType === 'Auto' ? undefined : evidenceType,
           entity_id: taggedPersonId ?? undefined,
         };
@@ -103,6 +159,7 @@ export function EvidenceCaptureSheet({
           url: urlValue,
           notes: urlNote || undefined,
           type: 'url',
+          status: 'unsorted',
           evidence_type: evidenceType === 'Auto' ? undefined : evidenceType,
           entity_id: taggedPersonId ?? undefined,
         };
@@ -111,19 +168,28 @@ export function EvidenceCaptureSheet({
         payload = {
           title: selectedFile?.name ?? 'Untitled file',
           type: 'file',
+          status: 'unsorted',
           evidence_type: evidenceType === 'Auto' ? undefined : evidenceType,
           entity_id: taggedPersonId ?? undefined,
           source_path: selectedFile?.name ?? undefined,
         };
       }
 
-      const result = (await investigationsApi.addEvidence(investigationId, payload)) as {
-        id: string;
-      };
-      onSaved(String(result.id));
-      onClose();
+      const raw = await investigationsApi.addEvidence(investigationId, payload);
+      const evidenceId =
+        typeof raw === 'object' && raw !== null && 'id' in raw
+          ? String((raw as { id: unknown }).id)
+          : '';
+      if (evidenceId) {
+        addToast({ text: 'Evidence saved — added to unsorted queue', type: 'success' });
+        onSaved(evidenceId);
+        onClose();
+      } else {
+        setSaveError('Save succeeded but evidence ID was missing.');
+      }
     } catch (err) {
       console.error('Evidence capture failed:', err);
+      setSaveError('Failed to save. Please try again.');
     } finally {
       setSaving(false);
     }
@@ -138,19 +204,19 @@ export function EvidenceCaptureSheet({
     evidenceType,
     taggedPersonId,
     investigationId,
+    addToast,
     onSaved,
     onClose,
   ]);
 
   // Prevent body scroll while sheet is open
   useEffect(() => {
+    const prev = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
     return () => {
-      document.body.style.overflow = '';
+      document.body.style.overflow = prev;
     };
   }, []);
-
-  const showPersonSuggestions = personSearch.length > 0 && !taggedPersonName && subjects.length > 0;
 
   return createPortal(
     <div
@@ -180,7 +246,10 @@ export function EvidenceCaptureSheet({
             <button
               key={m}
               className={`${styles.modeTab} ${mode === m ? styles.modeTabActive : ''}`}
-              onClick={() => setMode(m)}
+              onClick={() => {
+                setMode(m);
+                setSaveError(null);
+              }}
             >
               {m === 'note' && <FileText size={16} />}
               {m === 'file' && <Paperclip size={16} />}
@@ -198,7 +267,10 @@ export function EvidenceCaptureSheet({
                 placeholder="Type your observation…"
                 value={noteText}
                 maxLength={MAX_NOTE_CHARS}
-                onChange={(e) => setNoteText(e.target.value)}
+                onChange={(e) => {
+                  setNoteText(e.target.value);
+                  setSaveError(null);
+                }}
                 autoFocus
               />
               <span className={styles.charCount}>
@@ -213,7 +285,10 @@ export function EvidenceCaptureSheet({
                 ref={fileInputRef}
                 type="file"
                 className={styles.fileInput}
-                onChange={(e) => setSelectedFile(e.target.files?.[0] ?? null)}
+                onChange={(e) => {
+                  setSelectedFile(e.target.files?.[0] ?? null);
+                  setSaveError(null);
+                }}
               />
               <button
                 className={`${styles.fileZone} ${selectedFile ? styles.fileZoneSelected : ''}`}
@@ -234,7 +309,10 @@ export function EvidenceCaptureSheet({
                   className={styles.urlInput}
                   placeholder="https://…"
                   value={urlValue}
-                  onChange={(e) => setUrlValue(e.target.value)}
+                  onChange={(e) => {
+                    setUrlValue(e.target.value);
+                    setSaveError(null);
+                  }}
                   autoFocus
                 />
               </div>
@@ -274,43 +352,23 @@ export function EvidenceCaptureSheet({
                 onClick={() => {
                   setTaggedPersonId(null);
                   setTaggedPersonName('');
-                  setPersonSearch('');
                 }}
               >
                 {taggedPersonName} ✕
               </button>
             ) : (
-              <>
-                <input
-                  type="text"
-                  className={styles.autocompleteInput}
-                  placeholder="Search subjects…"
-                  value={personSearch}
-                  onChange={(e) => setPersonSearch(e.target.value)}
-                />
-                {showPersonSuggestions && (
-                  <div className={styles.suggestions}>
-                    {subjects.slice(0, 5).map((s) => (
-                      <button
-                        key={s.id}
-                        className={styles.suggestionRow}
-                        onClick={() => {
-                          setTaggedPersonId(String(s.id));
-                          setTaggedPersonName(s.name);
-                          setPersonSearch('');
-                        }}
-                      >
-                        {s.name}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </>
+              <PersonAutocomplete
+                onSelect={(id, name) => {
+                  setTaggedPersonId(id);
+                  setTaggedPersonName(name);
+                }}
+              />
             )}
           </div>
         </div>
 
         <div className={styles.footer}>
+          {saveError && <p className={styles.errorMsg}>{saveError}</p>}
           <button
             className={styles.saveBtn}
             disabled={!isContentReady || saving}

--- a/src/client/components/investigation/mobile/EvidenceCaptureSheet.tsx
+++ b/src/client/components/investigation/mobile/EvidenceCaptureSheet.tsx
@@ -72,7 +72,7 @@ export function EvidenceCaptureSheet({
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
     touchDeltaY.current = e.touches[0].clientY - touchStartY.current;
     if (touchDeltaY.current > 0 && sheetRef.current) {
-      sheetRef.current.style.transform = `translateY(${touchDeltaY.current}px)`;
+      sheetRef.current.style.setProperty('--sheet-translate', `${touchDeltaY.current}px`);
     }
   }, []);
 
@@ -80,7 +80,7 @@ export function EvidenceCaptureSheet({
     if (touchDeltaY.current > SWIPE_DISMISS_THRESHOLD) {
       onClose();
     } else if (sheetRef.current) {
-      sheetRef.current.style.transform = '';
+      sheetRef.current.style.setProperty('--sheet-translate', '0px');
     }
   }, [onClose]);
 

--- a/src/client/components/investigation/mobile/EvidenceCaptureSheet.tsx
+++ b/src/client/components/investigation/mobile/EvidenceCaptureSheet.tsx
@@ -1,0 +1,326 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { X, FileText, Paperclip, Link } from 'lucide-react';
+import { investigationsApi } from '../../../domains/investigations';
+import { useSubjectsQuery } from '../../../hooks/useSubjectsQuery';
+import styles from './EvidenceCaptureSheet.module.css';
+
+type CaptureMode = 'note' | 'file' | 'url';
+
+const EVIDENCE_TYPES = [
+  'Auto',
+  'Document',
+  'Testimony',
+  'Photo',
+  'URL',
+  'Note',
+  'Financial',
+  'Other',
+];
+const MAX_NOTE_CHARS = 2000;
+const SWIPE_DISMISS_THRESHOLD = 80;
+
+interface EvidenceCaptureSheetProps {
+  investigationId: string;
+  onClose: () => void;
+  onSaved: (evidenceId: string) => void;
+}
+
+export function EvidenceCaptureSheet({
+  investigationId,
+  onClose,
+  onSaved,
+}: EvidenceCaptureSheetProps) {
+  const [mode, setMode] = useState<CaptureMode>('note');
+  const [noteText, setNoteText] = useState('');
+  const [urlValue, setUrlValue] = useState('');
+  const [urlNote, setUrlNote] = useState('');
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [evidenceType, setEvidenceType] = useState('Auto');
+  const [personSearch, setPersonSearch] = useState('');
+  const [taggedPersonId, setTaggedPersonId] = useState<string | null>(null);
+  const [taggedPersonName, setTaggedPersonName] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const touchStartY = useRef(0);
+  const touchDeltaY = useRef(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { data: subjectsData } = useSubjectsQuery({
+    page: 1,
+    pageSize: 10,
+    searchTerm: personSearch,
+    entityType: 'all',
+    sortBy: 'name',
+    sortOrder: 'asc',
+    selectedRiskLevel: null,
+  });
+
+  const subjects = subjectsData?.subjects ?? [];
+
+  const isContentReady =
+    (mode === 'note' && noteText.trim().length > 0) ||
+    (mode === 'url' && urlValue.trim().length > 0) ||
+    (mode === 'file' && selectedFile !== null);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+    touchDeltaY.current = 0;
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    touchDeltaY.current = e.touches[0].clientY - touchStartY.current;
+    if (touchDeltaY.current > 0 && sheetRef.current) {
+      sheetRef.current.style.transform = `translateY(${touchDeltaY.current}px)`;
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (touchDeltaY.current > SWIPE_DISMISS_THRESHOLD) {
+      onClose();
+    } else if (sheetRef.current) {
+      sheetRef.current.style.transform = '';
+    }
+  }, [onClose]);
+
+  const handleSave = useCallback(async () => {
+    if (!isContentReady || saving) return;
+    setSaving(true);
+    try {
+      let payload: Record<string, unknown>;
+      if (mode === 'note') {
+        payload = {
+          title: noteText.slice(0, 80),
+          description: noteText,
+          type: 'note',
+          evidence_type: evidenceType === 'Auto' ? undefined : evidenceType,
+          entity_id: taggedPersonId ?? undefined,
+        };
+      } else if (mode === 'url') {
+        payload = {
+          title: urlValue.slice(0, 80),
+          url: urlValue,
+          notes: urlNote || undefined,
+          type: 'url',
+          evidence_type: evidenceType === 'Auto' ? undefined : evidenceType,
+          entity_id: taggedPersonId ?? undefined,
+        };
+      } else {
+        // file mode — record metadata; actual file upload is a future enhancement
+        payload = {
+          title: selectedFile?.name ?? 'Untitled file',
+          type: 'file',
+          evidence_type: evidenceType === 'Auto' ? undefined : evidenceType,
+          entity_id: taggedPersonId ?? undefined,
+          source_path: selectedFile?.name ?? undefined,
+        };
+      }
+
+      const result = (await investigationsApi.addEvidence(investigationId, payload)) as {
+        id: string;
+      };
+      onSaved(String(result.id));
+      onClose();
+    } catch (err) {
+      console.error('Evidence capture failed:', err);
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    isContentReady,
+    saving,
+    mode,
+    noteText,
+    urlValue,
+    urlNote,
+    selectedFile,
+    evidenceType,
+    taggedPersonId,
+    investigationId,
+    onSaved,
+    onClose,
+  ]);
+
+  // Prevent body scroll while sheet is open
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  const showPersonSuggestions = personSearch.length > 0 && !taggedPersonName && subjects.length > 0;
+
+  return createPortal(
+    <div
+      className={styles.backdrop}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={sheetRef}
+        className={styles.sheet}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        <div className={styles.dragHandle} />
+
+        <div className={styles.header}>
+          <span className={styles.title}>Capture Evidence</span>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            <X size={20} />
+          </button>
+        </div>
+
+        <div className={styles.modeTabs}>
+          {(['note', 'file', 'url'] as CaptureMode[]).map((m) => (
+            <button
+              key={m}
+              className={`${styles.modeTab} ${mode === m ? styles.modeTabActive : ''}`}
+              onClick={() => setMode(m)}
+            >
+              {m === 'note' && <FileText size={16} />}
+              {m === 'file' && <Paperclip size={16} />}
+              {m === 'url' && <Link size={16} />}
+              {m.charAt(0).toUpperCase() + m.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        <div className={styles.body}>
+          {mode === 'note' && (
+            <div className={styles.fieldGroup}>
+              <textarea
+                className={styles.textarea}
+                placeholder="Type your observation…"
+                value={noteText}
+                maxLength={MAX_NOTE_CHARS}
+                onChange={(e) => setNoteText(e.target.value)}
+                autoFocus
+              />
+              <span className={styles.charCount}>
+                {noteText.length}/{MAX_NOTE_CHARS}
+              </span>
+            </div>
+          )}
+
+          {mode === 'file' && (
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                className={styles.fileInput}
+                onChange={(e) => setSelectedFile(e.target.files?.[0] ?? null)}
+              />
+              <button
+                className={`${styles.fileZone} ${selectedFile ? styles.fileZoneSelected : ''}`}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Paperclip size={24} />
+                {selectedFile ? selectedFile.name : 'Tap to select a file or photo'}
+              </button>
+            </>
+          )}
+
+          {mode === 'url' && (
+            <>
+              <div className={styles.fieldGroup}>
+                <label className={styles.label}>URL</label>
+                <input
+                  type="url"
+                  className={styles.urlInput}
+                  placeholder="https://…"
+                  value={urlValue}
+                  onChange={(e) => setUrlValue(e.target.value)}
+                  autoFocus
+                />
+              </div>
+              <div className={styles.fieldGroup}>
+                <label className={styles.label}>Note (optional)</label>
+                <textarea
+                  className={`${styles.textarea} ${styles.urlNoteTextarea}`}
+                  placeholder="Add context…"
+                  value={urlNote}
+                  onChange={(e) => setUrlNote(e.target.value)}
+                />
+              </div>
+            </>
+          )}
+
+          {/* Optional fields */}
+          <div className={styles.fieldGroup}>
+            <label className={styles.label}>Type</label>
+            <select
+              className={styles.select}
+              value={evidenceType}
+              onChange={(e) => setEvidenceType(e.target.value)}
+            >
+              {EVIDENCE_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className={styles.fieldGroup}>
+            <label className={styles.label}>Tag person (optional)</label>
+            {taggedPersonName ? (
+              <button
+                className={styles.suggestionRow}
+                onClick={() => {
+                  setTaggedPersonId(null);
+                  setTaggedPersonName('');
+                  setPersonSearch('');
+                }}
+              >
+                {taggedPersonName} ✕
+              </button>
+            ) : (
+              <>
+                <input
+                  type="text"
+                  className={styles.autocompleteInput}
+                  placeholder="Search subjects…"
+                  value={personSearch}
+                  onChange={(e) => setPersonSearch(e.target.value)}
+                />
+                {showPersonSuggestions && (
+                  <div className={styles.suggestions}>
+                    {subjects.slice(0, 5).map((s) => (
+                      <button
+                        key={s.id}
+                        className={styles.suggestionRow}
+                        onClick={() => {
+                          setTaggedPersonId(String(s.id));
+                          setTaggedPersonName(s.name);
+                          setPersonSearch('');
+                        }}
+                      >
+                        {s.name}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className={styles.footer}>
+          <button
+            className={styles.saveBtn}
+            disabled={!isContentReady || saving}
+            onClick={handleSave}
+          >
+            {saving ? 'Saving…' : 'Save Evidence'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/client/components/investigation/mobile/MobileBoardView.module.css
+++ b/src/client/components/investigation/mobile/MobileBoardView.module.css
@@ -159,7 +159,7 @@
   background: var(--accent);
   border: none;
   border-radius: var(--radius-base);
-  color: #fff;
+  color: var(--text-on-accent, #fff);
   font-size: 1rem;
   font-weight: 700;
   cursor: pointer;
@@ -189,4 +189,9 @@
   color: var(--text-muted);
   padding: 2rem 0;
   font-size: 0.9375rem;
+}
+
+.errorMsg {
+  color: var(--accent-red);
+  font-size: 0.875rem;
 }

--- a/src/client/components/investigation/mobile/MobileBoardView.module.css
+++ b/src/client/components/investigation/mobile/MobileBoardView.module.css
@@ -1,0 +1,192 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.columnTabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  background: var(--glass-bg-strong);
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+}
+
+.columnTab {
+  flex: 1;
+  padding: 0.5rem 0.25rem;
+  background: none;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 2.75rem;
+}
+
+.columnTabActive {
+  background: var(--glass-bg-highlight);
+  color: var(--text-primary);
+  border-color: var(--accent);
+}
+
+.columnContent {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 1rem 1rem;
+}
+
+.card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  padding: 0.875rem;
+  margin-bottom: 0.625rem;
+}
+
+.cardTitle {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.375rem;
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.625rem;
+}
+
+.badge {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 100px;
+  background: var(--glass-bg-highlight);
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.cardActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.cardBtn {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: var(--radius-base);
+  border: 1px solid var(--glass-border);
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 2.75rem;
+}
+
+.cardBtn:hover {
+  background: var(--glass-bg-highlight);
+  color: var(--text-primary);
+}
+
+.addBtn {
+  width: 100%;
+  padding: 0.875rem;
+  border: 2px dashed var(--glass-border);
+  border-radius: var(--radius-base);
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 2.75rem;
+  margin-top: 0.5rem;
+}
+
+.sheet {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 300;
+  display: flex;
+  align-items: flex-end;
+}
+
+.sheetInner {
+  width: 100%;
+  background: var(--glass-bg-strong);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  padding: 1.5rem 1rem calc(1.5rem + env(safe-area-inset-bottom));
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sheetTitle {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.sheetInput {
+  width: 100%;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.sheetInput:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.sheetBtn {
+  width: 100%;
+  padding: 0.875rem;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-base);
+  color: #fff;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  min-height: 2.75rem;
+}
+
+.sheetBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.sheetNote {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.emptyState {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 2rem 0;
+  font-size: 0.9375rem;
+}
+
+.loadingState {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 2rem 0;
+  font-size: 0.9375rem;
+}

--- a/src/client/components/investigation/mobile/MobileBoardView.tsx
+++ b/src/client/components/investigation/mobile/MobileBoardView.tsx
@@ -26,12 +26,95 @@ interface CreateHypothesisResponse {
   status: string;
 }
 
+function HypothesisList({
+  hypotheses,
+  onMove,
+}: {
+  hypotheses: Hypothesis[];
+  onMove: (title: string) => void;
+}) {
+  if (hypotheses.length === 0) return <div className={styles.emptyState}>No hypotheses yet</div>;
+  return (
+    <>
+      {hypotheses.map((h) => (
+        <div key={h.id} className={styles.card}>
+          <div className={styles.cardTitle}>{h.title}</div>
+          <div className={styles.cardMeta}>
+            <span className={styles.badge}>{h.status}</span>
+          </div>
+          <div className={styles.cardActions}>
+            <button className={styles.cardBtn} onClick={() => onMove(h.title)}>
+              Move
+            </button>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function EvidenceList({
+  evidence,
+  onMove,
+}: {
+  evidence: EvidenceItem[];
+  onMove: (title: string) => void;
+}) {
+  if (evidence.length === 0) return <div className={styles.emptyState}>No evidence yet</div>;
+  return (
+    <>
+      {evidence.map((ev) => (
+        <div key={ev.id} className={styles.card}>
+          <div className={styles.cardTitle}>{ev.title ?? 'Untitled'}</div>
+          <div className={styles.cardMeta}>
+            <span className={styles.badge}>{ev.type}</span>
+            <span className={styles.badge}>{ev.relevance}</span>
+          </div>
+          <div className={styles.cardActions}>
+            <button className={styles.cardBtn} onClick={() => onMove(ev.title ?? 'Untitled')}>
+              Move
+            </button>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function NarrativeList({
+  items,
+  onMove,
+}: {
+  items: EvidenceItem[];
+  onMove: (title: string) => void;
+}) {
+  if (items.length === 0) return <div className={styles.emptyState}>No narrative items yet</div>;
+  return (
+    <>
+      {items.map((ev) => (
+        <div key={ev.id} className={styles.card}>
+          <div className={styles.cardTitle}>{ev.title ?? 'Untitled'}</div>
+          <div className={styles.cardMeta}>
+            <span className={styles.badge}>{ev.type}</span>
+          </div>
+          <div className={styles.cardActions}>
+            <button className={styles.cardBtn} onClick={() => onMove(ev.title ?? 'Untitled')}>
+              Move
+            </button>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
 export function MobileBoardView({ investigationId }: MobileBoardViewProps) {
   const [activeColumn, setActiveColumn] = useState<Column>('hypotheses');
   const [addSheet, setAddSheet] = useState<AddSheetState>(null);
   const [moveSheet, setMoveSheet] = useState<MoveSheetState>(null);
   const [addTitle, setAddTitle] = useState('');
   const [saving, setSaving] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
   const touchStartX = useRef(0);
   const colIndex = COLUMNS.indexOf(activeColumn);
 
@@ -94,6 +177,7 @@ export function MobileBoardView({ investigationId }: MobileBoardViewProps) {
       setAddTitle('');
     } catch (err) {
       console.error('Add card failed:', err);
+      setAddError('Failed to add. Please try again.');
     } finally {
       setSaving(false);
     }
@@ -101,65 +185,23 @@ export function MobileBoardView({ investigationId }: MobileBoardViewProps) {
 
   const renderCards = () => {
     if (loadingShell) return <div className={styles.loadingState}>Loading...</div>;
-
-    if (activeColumn === 'hypotheses') {
-      if (hypotheses.length === 0)
-        return <div className={styles.emptyState}>No hypotheses yet</div>;
-      return hypotheses.map((h) => (
-        <div key={h.id} className={styles.card}>
-          <div className={styles.cardTitle}>{h.title}</div>
-          <div className={styles.cardMeta}>
-            <span className={styles.badge}>{h.status}</span>
-          </div>
-          <div className={styles.cardActions}>
-            <button className={styles.cardBtn} onClick={() => setMoveSheet({ cardTitle: h.title })}>
-              Move
-            </button>
-          </div>
-        </div>
-      ));
-    }
-
-    if (activeColumn === 'evidence') {
-      if (evidence.length === 0) return <div className={styles.emptyState}>No evidence yet</div>;
-      return evidence.map((ev) => (
-        <div key={ev.id} className={styles.card}>
-          <div className={styles.cardTitle}>{ev.title ?? 'Untitled'}</div>
-          <div className={styles.cardMeta}>
-            <span className={styles.badge}>{ev.type}</span>
-            <span className={styles.badge}>{ev.relevance}</span>
-          </div>
-          <div className={styles.cardActions}>
-            <button
-              className={styles.cardBtn}
-              onClick={() => setMoveSheet({ cardTitle: ev.title ?? 'Untitled' })}
-            >
-              Move
-            </button>
-          </div>
-        </div>
-      ));
-    }
-
-    // narrative
-    if (narrativeItems.length === 0)
-      return <div className={styles.emptyState}>No narrative items yet</div>;
-    return narrativeItems.map((ev) => (
-      <div key={ev.id} className={styles.card}>
-        <div className={styles.cardTitle}>{ev.title ?? 'Untitled'}</div>
-        <div className={styles.cardMeta}>
-          <span className={styles.badge}>{ev.type}</span>
-        </div>
-        <div className={styles.cardActions}>
-          <button
-            className={styles.cardBtn}
-            onClick={() => setMoveSheet({ cardTitle: ev.title ?? 'Untitled' })}
-          >
-            Move
-          </button>
-        </div>
-      </div>
-    ));
+    if (activeColumn === 'hypotheses')
+      return (
+        <HypothesisList
+          hypotheses={hypotheses}
+          onMove={(title) => setMoveSheet({ cardTitle: title })}
+        />
+      );
+    if (activeColumn === 'evidence')
+      return (
+        <EvidenceList evidence={evidence} onMove={(title) => setMoveSheet({ cardTitle: title })} />
+      );
+    return (
+      <NarrativeList
+        items={narrativeItems}
+        onMove={(title) => setMoveSheet({ cardTitle: title })}
+      />
+    );
   };
 
   return (
@@ -178,16 +220,30 @@ export function MobileBoardView({ investigationId }: MobileBoardViewProps) {
 
       <div className={styles.columnContent}>
         {renderCards()}
-        <button className={styles.addBtn} onClick={() => setAddSheet({ column: activeColumn })}>
+        <button
+          className={styles.addBtn}
+          onClick={() => {
+            setAddSheet({ column: activeColumn });
+            setAddError(null);
+          }}
+        >
           + Add to {COLUMN_LABELS[activeColumn]}
         </button>
       </div>
 
       {/* Add sheet */}
       {addSheet !== null && (
-        <div className={styles.sheet} onClick={() => setAddSheet(null)}>
+        <div
+          className={styles.sheet}
+          onClick={() => {
+            setAddSheet(null);
+            setAddTitle('');
+            setAddError(null);
+          }}
+        >
           <div className={styles.sheetInner} onClick={(ev) => ev.stopPropagation()}>
             <div className={styles.sheetTitle}>Add to {COLUMN_LABELS[addSheet.column]}</div>
+            {addError !== null && <div className={styles.errorMsg}>{addError}</div>}
             <input
               type="text"
               className={styles.sheetInput}

--- a/src/client/components/investigation/mobile/MobileBoardView.tsx
+++ b/src/client/components/investigation/mobile/MobileBoardView.tsx
@@ -1,0 +1,226 @@
+import React, { useState, useRef, useCallback } from 'react';
+import { useInvestigationBoard } from '../../../domains/investigations';
+import { apiClient } from '../../../services/apiClient';
+import type { Hypothesis, EvidenceItem } from '../../../../types/investigation';
+import styles from './MobileBoardView.module.css';
+
+type Column = 'hypotheses' | 'evidence' | 'narrative';
+const COLUMNS: Column[] = ['hypotheses', 'evidence', 'narrative'];
+const COLUMN_LABELS: Record<Column, string> = {
+  hypotheses: 'Hypotheses',
+  evidence: 'Evidence',
+  narrative: 'Narrative',
+};
+const SWIPE_THRESHOLD = 60;
+
+interface MobileBoardViewProps {
+  investigationId: string;
+}
+
+type AddSheetState = { column: Column } | null;
+type MoveSheetState = { cardTitle: string } | null;
+
+interface CreateHypothesisResponse {
+  id: string | number;
+  title: string;
+  status: string;
+}
+
+export function MobileBoardView({ investigationId }: MobileBoardViewProps) {
+  const [activeColumn, setActiveColumn] = useState<Column>('hypotheses');
+  const [addSheet, setAddSheet] = useState<AddSheetState>(null);
+  const [moveSheet, setMoveSheet] = useState<MoveSheetState>(null);
+  const [addTitle, setAddTitle] = useState('');
+  const [saving, setSaving] = useState(false);
+  const touchStartX = useRef(0);
+  const colIndex = COLUMNS.indexOf(activeColumn);
+
+  const { hypotheses, evidence, notebook, loadingShell, setHypotheses } =
+    useInvestigationBoard(investigationId);
+
+  // Narrative column: evidence items ordered by notebook
+  const narrativeItems = notebook
+    .map((id) => evidence.find((e) => String(e.id) === String(id)))
+    .filter((e): e is EvidenceItem => e !== undefined);
+
+  const handleTouchStart = useCallback((ev: React.TouchEvent) => {
+    touchStartX.current = ev.touches[0].clientX;
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (ev: React.TouchEvent) => {
+      const delta = ev.changedTouches[0].clientX - touchStartX.current;
+      if (delta < -SWIPE_THRESHOLD) {
+        setActiveColumn(COLUMNS[Math.min(colIndex + 1, COLUMNS.length - 1)]);
+      } else if (delta > SWIPE_THRESHOLD) {
+        setActiveColumn(COLUMNS[Math.max(colIndex - 1, 0)]);
+      }
+    },
+    [colIndex],
+  );
+
+  const handleAddSave = useCallback(async () => {
+    if (!addTitle.trim() || !addSheet || saving) return;
+    setSaving(true);
+    try {
+      if (addSheet.column === 'hypotheses') {
+        const created = await apiClient.post<CreateHypothesisResponse>(
+          `/investigations/${investigationId}/hypotheses`,
+          { title: addTitle, description: '' },
+        );
+        setHypotheses((prev: Hypothesis[]) => [
+          ...prev,
+          {
+            id: String(created.id),
+            investigationId,
+            title: created.title,
+            description: '',
+            status: (created.status as Hypothesis['status']) || 'proposed',
+            evidence: [],
+            confidence: 0,
+            createdBy: 'system',
+            createdAt: new Date(),
+            relatedHypotheses: [],
+          },
+        ]);
+      } else {
+        // Evidence and Narrative: add to unsorted queue
+        await apiClient.post(`/investigations/${investigationId}/evidence`, {
+          title: addTitle,
+          status: 'unsorted',
+        });
+      }
+      setAddSheet(null);
+      setAddTitle('');
+    } catch (err) {
+      console.error('Add card failed:', err);
+    } finally {
+      setSaving(false);
+    }
+  }, [addTitle, addSheet, saving, investigationId, setHypotheses]);
+
+  const renderCards = () => {
+    if (loadingShell) return <div className={styles.loadingState}>Loading...</div>;
+
+    if (activeColumn === 'hypotheses') {
+      if (hypotheses.length === 0)
+        return <div className={styles.emptyState}>No hypotheses yet</div>;
+      return hypotheses.map((h) => (
+        <div key={h.id} className={styles.card}>
+          <div className={styles.cardTitle}>{h.title}</div>
+          <div className={styles.cardMeta}>
+            <span className={styles.badge}>{h.status}</span>
+          </div>
+          <div className={styles.cardActions}>
+            <button className={styles.cardBtn} onClick={() => setMoveSheet({ cardTitle: h.title })}>
+              Move
+            </button>
+          </div>
+        </div>
+      ));
+    }
+
+    if (activeColumn === 'evidence') {
+      if (evidence.length === 0) return <div className={styles.emptyState}>No evidence yet</div>;
+      return evidence.map((ev) => (
+        <div key={ev.id} className={styles.card}>
+          <div className={styles.cardTitle}>{ev.title ?? 'Untitled'}</div>
+          <div className={styles.cardMeta}>
+            <span className={styles.badge}>{ev.type}</span>
+            <span className={styles.badge}>{ev.relevance}</span>
+          </div>
+          <div className={styles.cardActions}>
+            <button
+              className={styles.cardBtn}
+              onClick={() => setMoveSheet({ cardTitle: ev.title ?? 'Untitled' })}
+            >
+              Move
+            </button>
+          </div>
+        </div>
+      ));
+    }
+
+    // narrative
+    if (narrativeItems.length === 0)
+      return <div className={styles.emptyState}>No narrative items yet</div>;
+    return narrativeItems.map((ev) => (
+      <div key={ev.id} className={styles.card}>
+        <div className={styles.cardTitle}>{ev.title ?? 'Untitled'}</div>
+        <div className={styles.cardMeta}>
+          <span className={styles.badge}>{ev.type}</span>
+        </div>
+        <div className={styles.cardActions}>
+          <button
+            className={styles.cardBtn}
+            onClick={() => setMoveSheet({ cardTitle: ev.title ?? 'Untitled' })}
+          >
+            Move
+          </button>
+        </div>
+      </div>
+    ));
+  };
+
+  return (
+    <div className={styles.root} onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
+      <div className={styles.columnTabs}>
+        {COLUMNS.map((col) => (
+          <button
+            key={col}
+            className={`${styles.columnTab} ${activeColumn === col ? styles.columnTabActive : ''}`}
+            onClick={() => setActiveColumn(col)}
+          >
+            {COLUMN_LABELS[col]}
+          </button>
+        ))}
+      </div>
+
+      <div className={styles.columnContent}>
+        {renderCards()}
+        <button className={styles.addBtn} onClick={() => setAddSheet({ column: activeColumn })}>
+          + Add to {COLUMN_LABELS[activeColumn]}
+        </button>
+      </div>
+
+      {/* Add sheet */}
+      {addSheet !== null && (
+        <div className={styles.sheet} onClick={() => setAddSheet(null)}>
+          <div className={styles.sheetInner} onClick={(ev) => ev.stopPropagation()}>
+            <div className={styles.sheetTitle}>Add to {COLUMN_LABELS[addSheet.column]}</div>
+            <input
+              type="text"
+              className={styles.sheetInput}
+              placeholder="Title"
+              value={addTitle}
+              onChange={(ev) => setAddTitle(ev.target.value)}
+              autoFocus
+            />
+            <button
+              className={styles.sheetBtn}
+              disabled={!addTitle.trim() || saving}
+              onClick={handleAddSave}
+            >
+              {saving ? 'Saving...' : 'Add'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Move sheet — informs user full editing is on desktop */}
+      {moveSheet !== null && (
+        <div className={styles.sheet} onClick={() => setMoveSheet(null)}>
+          <div className={styles.sheetInner} onClick={(ev) => ev.stopPropagation()}>
+            <div className={styles.sheetTitle}>Move Card</div>
+            <p className={styles.sheetNote}>
+              Full card editing and moving between columns is available on desktop.
+            </p>
+            <button className={styles.sheetBtn} onClick={() => setMoveSheet(null)}>
+              OK
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/components/investigation/mobile/MobileBottomNav.module.css
+++ b/src/client/components/investigation/mobile/MobileBottomNav.module.css
@@ -1,0 +1,67 @@
+.nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 4.5rem;
+  display: flex;
+  align-items: center;
+  background: var(--glass-bg-strong);
+  border-top: 1px solid var(--glass-border);
+  padding-bottom: env(safe-area-inset-bottom);
+  z-index: 100;
+}
+
+.slot {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  min-height: 2.75rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  padding: 0;
+}
+
+.slotActive {
+  color: var(--accent);
+}
+
+.label {
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fabSlot {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 0;
+}
+
+.fab {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  margin-top: -1.125rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  flex-shrink: 0;
+}
+
+.fab:active {
+  transform: scale(0.95);
+}

--- a/src/client/components/investigation/mobile/MobileBottomNav.tsx
+++ b/src/client/components/investigation/mobile/MobileBottomNav.tsx
@@ -1,0 +1,60 @@
+import { LayoutDashboard, FileText, Plus, Activity, MoreHorizontal } from 'lucide-react';
+import styles from './MobileBottomNav.module.css';
+
+type ActiveDest = 'board' | 'evidence' | 'activity';
+
+interface MobileBottomNavProps {
+  activeDest: ActiveDest;
+  onSetActiveDest: (dest: ActiveDest) => void;
+  onCapture: () => void;
+  onMore: () => void;
+}
+
+export function MobileBottomNav({
+  activeDest,
+  onSetActiveDest,
+  onCapture,
+  onMore,
+}: MobileBottomNavProps) {
+  return (
+    <nav className={styles.nav} aria-label="Investigation navigation">
+      <button
+        className={`${styles.slot} ${activeDest === 'board' ? styles.slotActive : ''}`}
+        onClick={() => onSetActiveDest('board')}
+        aria-label="Board"
+      >
+        <LayoutDashboard size={20} />
+        <span className={styles.label}>Board</span>
+      </button>
+
+      <button
+        className={`${styles.slot} ${activeDest === 'evidence' ? styles.slotActive : ''}`}
+        onClick={() => onSetActiveDest('evidence')}
+        aria-label="Evidence"
+      >
+        <FileText size={20} />
+        <span className={styles.label}>Evidence</span>
+      </button>
+
+      <div className={styles.fabSlot}>
+        <button className={styles.fab} onClick={onCapture} aria-label="Capture evidence">
+          <Plus size={24} />
+        </button>
+      </div>
+
+      <button
+        className={`${styles.slot} ${activeDest === 'activity' ? styles.slotActive : ''}`}
+        onClick={() => onSetActiveDest('activity')}
+        aria-label="Activity"
+      >
+        <Activity size={20} />
+        <span className={styles.label}>Activity</span>
+      </button>
+
+      <button className={styles.slot} onClick={onMore} aria-label="More tools">
+        <MoreHorizontal size={20} />
+        <span className={styles.label}>More</span>
+      </button>
+    </nav>
+  );
+}

--- a/src/client/components/investigation/mobile/MobileEvidenceList.module.css
+++ b/src/client/components/investigation/mobile/MobileEvidenceList.module.css
@@ -1,0 +1,176 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.stickyHeader {
+  background: var(--glass-bg-strong);
+  border-bottom: 1px solid var(--glass-border);
+  padding: 0.75rem 1rem 0;
+  flex-shrink: 0;
+}
+
+.searchInput {
+  width: 100%;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  padding: 0.625rem 0.875rem;
+  box-sizing: border-box;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.filterRow {
+  display: flex;
+  gap: 0.375rem;
+  overflow-x: auto;
+  padding: 0.625rem 0;
+  scrollbar-width: none;
+}
+
+.filterRow::-webkit-scrollbar {
+  display: none;
+}
+
+.chip {
+  flex-shrink: 0;
+  padding: 0.375rem 0.875rem;
+  border-radius: 100px;
+  border: 1px solid var(--glass-border);
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  min-height: 2.75rem;
+  display: flex;
+  align-items: center;
+  font-family: inherit;
+}
+
+.chipActive {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--text-on-accent, #fff);
+}
+
+.list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+}
+
+.groupHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.5rem 0 0.375rem;
+}
+
+.unsortedDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex-shrink: 0;
+}
+
+.card {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  padding: 0.875rem;
+  margin-bottom: 0.625rem;
+}
+
+.cardTop {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.375rem;
+}
+
+.typeLabel {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.1875rem 0.5rem;
+  border-radius: 100px;
+  background: var(--glass-bg-highlight);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.cardTitle {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  flex-wrap: wrap;
+  margin-bottom: 0.625rem;
+}
+
+.flaggedBadge {
+  color: var(--accent-red, #ef4444);
+  font-weight: 700;
+  font-size: 0.75rem;
+}
+
+.cardActions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.cardBtn {
+  flex: 1;
+  padding: 0.5rem;
+  border-radius: var(--radius-base);
+  border: 1px solid var(--glass-border);
+  background: none;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.cardBtn:hover {
+  background: var(--glass-bg-highlight);
+  color: var(--text-primary);
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9375rem;
+  padding: 3rem 1rem;
+}

--- a/src/client/components/investigation/mobile/MobileEvidenceList.tsx
+++ b/src/client/components/investigation/mobile/MobileEvidenceList.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { investigationsApi } from '../../../domains/investigations';
 import type { InvestigationCaseEvidenceItemDto } from '@shared/dto/investigations';
 import styles from './MobileEvidenceList.module.css';
@@ -21,21 +22,35 @@ function isFlagged(item: InvestigationCaseEvidenceItemDto): boolean {
 }
 
 export function MobileEvidenceList({ investigationId }: MobileEvidenceListProps) {
+  const navigate = useNavigate();
   const [evidence, setEvidence] = useState<InvestigationCaseEvidenceItemDto[]>([]);
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState<FilterChip>('All');
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
+    setFetchError(null);
     investigationsApi
       .getCaseFolder(investigationId)
       .then((folder) => {
         setEvidence(folder.all ?? []);
       })
-      .catch(console.error)
+      .catch((error) => {
+        console.error(error);
+        setFetchError('Failed to load evidence.');
+      })
       .finally(() => setLoading(false));
   }, [investigationId]);
+
+  const handleView = (item: InvestigationCaseEvidenceItemDto) => {
+    if (item.documentId) {
+      navigate(`/documents?id=${item.documentId}`);
+    } else if (item.sourcePath) {
+      window.open(`/files/${encodeURIComponent(item.sourcePath)}`, '_blank', 'noopener');
+    }
+  };
 
   const filtered = evidence.filter((item) => {
     const matchesSearch =
@@ -56,6 +71,10 @@ export function MobileEvidenceList({ investigationId }: MobileEvidenceListProps)
 
   if (loading) {
     return <div className={styles.empty}>Loading evidence...</div>;
+  }
+
+  if (fetchError) {
+    return <div className={styles.empty}>{fetchError}</div>;
   }
 
   return (
@@ -89,7 +108,7 @@ export function MobileEvidenceList({ investigationId }: MobileEvidenceListProps)
               Unsorted
             </div>
             {unsorted.map((item) => (
-              <EvidenceCard key={item.id} item={item} />
+              <EvidenceCard key={item.id} item={item} onView={handleView} />
             ))}
           </>
         )}
@@ -98,7 +117,7 @@ export function MobileEvidenceList({ investigationId }: MobileEvidenceListProps)
           <>
             <div className={styles.groupHeader}>Evidence</div>
             {sorted.map((item) => (
-              <EvidenceCard key={item.id} item={item} />
+              <EvidenceCard key={item.id} item={item} onView={handleView} />
             ))}
           </>
         )}
@@ -111,14 +130,11 @@ export function MobileEvidenceList({ investigationId }: MobileEvidenceListProps)
 
 interface EvidenceCardProps {
   item: InvestigationCaseEvidenceItemDto;
+  onView: (item: InvestigationCaseEvidenceItemDto) => void;
 }
 
-function EvidenceCard({ item }: EvidenceCardProps) {
-  const handleView = () => {
-    if (item.sourcePath) {
-      window.open(`/files/${encodeURIComponent(item.sourcePath)}`, '_blank');
-    }
-  };
+function EvidenceCard({ item, onView }: EvidenceCardProps) {
+  const canView = !!item.documentId || !!item.sourcePath;
 
   return (
     <div className={styles.card}>
@@ -133,7 +149,7 @@ function EvidenceCard({ item }: EvidenceCardProps) {
         {item.relevance && <span>{item.relevance}</span>}
       </div>
       <div className={styles.cardActions}>
-        <button className={styles.cardBtn} onClick={handleView} disabled={!item.sourcePath}>
+        <button className={styles.cardBtn} onClick={() => onView(item)} disabled={!canView}>
           View
         </button>
       </div>

--- a/src/client/components/investigation/mobile/MobileEvidenceList.tsx
+++ b/src/client/components/investigation/mobile/MobileEvidenceList.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from 'react';
+import { investigationsApi } from '../../../domains/investigations';
+import type { InvestigationCaseEvidenceItemDto } from '@shared/dto/investigations';
+import styles from './MobileEvidenceList.module.css';
+
+const FILTER_CHIPS = ['All', 'Documents', 'Testimony', 'Unsorted', 'Flagged'] as const;
+type FilterChip = (typeof FILTER_CHIPS)[number];
+
+interface MobileEvidenceListProps {
+  investigationId: string;
+}
+
+/** Items without an evidenceLadder assignment are treated as "unsorted". */
+function isUnsorted(item: InvestigationCaseEvidenceItemDto): boolean {
+  return !item.evidenceLadder;
+}
+
+/** Items with a non-zero redFlagRating are treated as "flagged". */
+function isFlagged(item: InvestigationCaseEvidenceItemDto): boolean {
+  return (item.redFlagRating ?? 0) > 0;
+}
+
+export function MobileEvidenceList({ investigationId }: MobileEvidenceListProps) {
+  const [evidence, setEvidence] = useState<InvestigationCaseEvidenceItemDto[]>([]);
+  const [search, setSearch] = useState('');
+  const [filter, setFilter] = useState<FilterChip>('All');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    investigationsApi
+      .getCaseFolder(investigationId)
+      .then((folder) => {
+        setEvidence(folder.all ?? []);
+      })
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [investigationId]);
+
+  const filtered = evidence.filter((item) => {
+    const matchesSearch =
+      search === '' || (item.title ?? '').toLowerCase().includes(search.toLowerCase());
+
+    const matchesFilter =
+      filter === 'All' ||
+      (filter === 'Unsorted' && isUnsorted(item)) ||
+      (filter === 'Flagged' && isFlagged(item)) ||
+      (filter === 'Documents' && item.type === 'document') ||
+      (filter === 'Testimony' && item.type === 'testimony');
+
+    return matchesSearch && matchesFilter;
+  });
+
+  const unsorted = filtered.filter(isUnsorted);
+  const sorted = filtered.filter((item) => !isUnsorted(item));
+
+  if (loading) {
+    return <div className={styles.empty}>Loading evidence...</div>;
+  }
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.stickyHeader}>
+        <input
+          type="search"
+          className={styles.searchInput}
+          placeholder="Search evidence..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <div className={styles.filterRow}>
+          {FILTER_CHIPS.map((chip) => (
+            <button
+              key={chip}
+              className={`${styles.chip} ${filter === chip ? styles.chipActive : ''}`}
+              onClick={() => setFilter(chip)}
+            >
+              {chip}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.list}>
+        {unsorted.length > 0 && (
+          <>
+            <div className={styles.groupHeader}>
+              <span className={styles.unsortedDot} />
+              Unsorted
+            </div>
+            {unsorted.map((item) => (
+              <EvidenceCard key={item.id} item={item} />
+            ))}
+          </>
+        )}
+
+        {sorted.length > 0 && (
+          <>
+            <div className={styles.groupHeader}>Evidence</div>
+            {sorted.map((item) => (
+              <EvidenceCard key={item.id} item={item} />
+            ))}
+          </>
+        )}
+
+        {filtered.length === 0 && <div className={styles.empty}>No evidence found</div>}
+      </div>
+    </div>
+  );
+}
+
+interface EvidenceCardProps {
+  item: InvestigationCaseEvidenceItemDto;
+}
+
+function EvidenceCard({ item }: EvidenceCardProps) {
+  const handleView = () => {
+    if (item.sourcePath) {
+      window.open(`/files/${encodeURIComponent(item.sourcePath)}`, '_blank');
+    }
+  };
+
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardTop}>
+        <span className={styles.typeLabel}>{item.type ?? 'unknown'}</span>
+        <span className={styles.cardTitle}>{item.title ?? 'Untitled'}</span>
+      </div>
+      <div className={styles.cardMeta}>
+        {isFlagged(item) && (
+          <span className={styles.flaggedBadge}>Flagged ({item.redFlagRating})</span>
+        )}
+        {item.relevance && <span>{item.relevance}</span>}
+      </div>
+      <div className={styles.cardActions}>
+        <button className={styles.cardBtn} onClick={handleView} disabled={!item.sourcePath}>
+          View
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/investigation/mobile/MobileForensicView.module.css
+++ b/src/client/components/investigation/mobile/MobileForensicView.module.css
@@ -1,0 +1,52 @@
+/* MobileForensicView.module.css */
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.tabs {
+  display: flex;
+  overflow-x: auto;
+  scrollbar-width: none;
+  background: var(--glass-bg-strong);
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.tab {
+  flex-shrink: 0;
+  padding: 0.75rem 1rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.tabActive {
+  border-bottom-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.placeholder {
+  padding: 1.5rem;
+  color: var(--text-muted);
+  text-align: center;
+  font-size: 0.9375rem;
+}

--- a/src/client/components/investigation/mobile/MobileForensicView.tsx
+++ b/src/client/components/investigation/mobile/MobileForensicView.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Investigation } from '../../../types/investigation';
+import { MultiSourceCorrelationEngine } from '../MultiSourceCorrelationEngine';
+import ForensicReportGenerator from '../ForensicReportGenerator';
+import FinancialTransactionMapper from '../../visualizations/FinancialTransactionMapper';
+import { CommunicationAnalysis } from '../CommunicationAnalysis';
+import styles from './MobileForensicView.module.css';
+
+type ForensicTab = 'documents' | 'correlation' | 'financial' | 'reports' | 'communication';
+
+interface Tab {
+  id: ForensicTab;
+  label: string;
+}
+
+const TABS: Tab[] = [
+  { id: 'documents', label: 'Documents' },
+  { id: 'correlation', label: 'Correlation' },
+  { id: 'financial', label: 'Financial' },
+  { id: 'reports', label: 'Reports' },
+  { id: 'communication', label: 'Communication' },
+];
+
+interface MobileForensicViewProps {
+  investigation: Investigation;
+}
+
+export function MobileForensicView({ investigation }: MobileForensicViewProps) {
+  const [activeTab, setActiveTab] = useState<ForensicTab>('documents');
+
+  const renderContent = () => {
+    switch (activeTab) {
+      case 'documents':
+        return <div className={styles.placeholder}>Select a document to analyze</div>;
+      case 'correlation':
+        return <MultiSourceCorrelationEngine mobileMode />;
+      case 'financial':
+        return <FinancialTransactionMapper investigationId={investigation.id} />;
+      case 'reports':
+        return (
+          <ForensicReportGenerator
+            investigationId={
+              typeof investigation.id === 'string' ? Number(investigation.id) : investigation.id
+            }
+            mobileMode
+          />
+        );
+      case 'communication':
+        return <CommunicationAnalysis investigation={investigation} evidence={[]} mobileMode />;
+    }
+  };
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.tabs} role="tablist">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            className={`${styles.tab}${activeTab === tab.id ? ` ${styles.tabActive}` : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className={styles.content} role="tabpanel">
+        {renderContent()}
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/investigation/mobile/MobileInvestigationShell.module.css
+++ b/src/client/components/investigation/mobile/MobileInvestigationShell.module.css
@@ -1,0 +1,46 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  background: var(--lq-surface-1);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  padding-top: calc(0.75rem + env(safe-area-inset-top));
+  background: var(--glass-bg-strong);
+  border-bottom: 1px solid var(--glass-border);
+  flex-shrink: 0;
+}
+
+.invTitle {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.notifBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+}
+
+.content {
+  flex: 1;
+  overflow: hidden;
+  padding-bottom: 4.5rem;
+}

--- a/src/client/components/investigation/mobile/MobileInvestigationShell.tsx
+++ b/src/client/components/investigation/mobile/MobileInvestigationShell.tsx
@@ -1,0 +1,155 @@
+import { useState, useCallback } from 'react';
+import { Bell } from 'lucide-react';
+import type {
+  Investigation,
+  TimelineEvent,
+  Investigator,
+  EvidenceItem,
+  Hypothesis,
+  Annotation,
+} from '../../../../types/investigation';
+import { MobileBottomNav } from './MobileBottomNav';
+import { EvidenceCaptureSheet } from './EvidenceCaptureSheet';
+import { MobileBoardView } from './MobileBoardView';
+import { MobileEvidenceList } from './MobileEvidenceList';
+import { MobileMoreDrawer, type MoreTool } from './MobileMoreDrawer';
+import { MobileToolScreen } from './MobileToolScreen';
+import { MobileTimelineView } from './MobileTimelineView';
+import { MobileForensicView } from './MobileForensicView';
+import { InvestigationActivityFeed } from '../InvestigationActivityFeed';
+import { CommunicationAnalysis } from '../CommunicationAnalysis';
+import { HypothesisTestingFramework } from '../HypothesisTestingFramework';
+import { InvestigationExportTools } from '../InvestigationExportTools';
+import styles from './MobileInvestigationShell.module.css';
+
+type ActiveDest = 'board' | 'evidence' | 'activity';
+
+const TOOL_LABELS: Record<MoreTool, string> = {
+  timeline: 'Event Chronology',
+  forensic: 'Forensic Workbench',
+  communications: 'Communications',
+  hypotheses: 'Hypotheses',
+  export: 'Export & Report',
+};
+
+interface MobileInvestigationShellProps {
+  investigationId?: string;
+  onInvestigationSelect?: (investigation: Investigation) => void;
+  currentUser: Investigator;
+  selectedInvestigation: Investigation;
+  timelineEvents: TimelineEvent[];
+  evidenceItems: EvidenceItem[];
+  onTimelineChanged?: () => void;
+}
+
+export function MobileInvestigationShell({
+  currentUser: _currentUser,
+  selectedInvestigation,
+  timelineEvents,
+  evidenceItems,
+  onTimelineChanged,
+}: MobileInvestigationShellProps) {
+  const invId = String(selectedInvestigation.id);
+
+  const [activeDest, setActiveDest] = useState<ActiveDest>('board');
+  const [moreDest, setMoreDest] = useState<MoreTool | null>(null);
+  const [captureOpen, setCaptureOpen] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [hypotheses, setHypotheses] = useState<Hypothesis[]>([]);
+
+  const handleEvidenceSaved = useCallback((_evidenceId: string) => {
+    setCaptureOpen(false);
+  }, []);
+
+  const handleSelectMore = useCallback((tool: MoreTool) => {
+    setMoreDest(tool);
+  }, []);
+
+  const handleBackFromTool = useCallback(() => {
+    setMoreDest(null);
+  }, []);
+
+  const handleHypothesesUpdate = useCallback((updated: unknown[]) => {
+    setHypotheses(updated as Hypothesis[]);
+  }, []);
+
+  // When a more tool is open, render just the MobileToolScreen
+  if (moreDest !== null) {
+    return (
+      <MobileToolScreen toolName={TOOL_LABELS[moreDest]} onBack={handleBackFromTool}>
+        {moreDest === 'timeline' && (
+          <MobileTimelineView
+            investigationId={invId}
+            timelineEvents={timelineEvents}
+            onEventsChanged={onTimelineChanged}
+          />
+        )}
+        {moreDest === 'forensic' && <MobileForensicView investigation={selectedInvestigation} />}
+        {moreDest === 'communications' && (
+          <CommunicationAnalysis
+            investigation={selectedInvestigation}
+            evidence={evidenceItems}
+            mobileMode
+          />
+        )}
+        {moreDest === 'hypotheses' && (
+          <HypothesisTestingFramework
+            investigationId={invId}
+            evidenceItems={evidenceItems}
+            onHypothesesUpdate={
+              handleHypothesesUpdate as Parameters<
+                typeof HypothesisTestingFramework
+              >[0]['onHypothesesUpdate']
+            }
+            mobileMode
+          />
+        )}
+        {moreDest === 'export' && (
+          <InvestigationExportTools
+            investigation={selectedInvestigation}
+            evidence={evidenceItems}
+            timelineEvents={timelineEvents}
+            hypotheses={hypotheses}
+            annotations={[] as Annotation[]}
+          />
+        )}
+      </MobileToolScreen>
+    );
+  }
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.header}>
+        <span className={styles.invTitle}>{selectedInvestigation.title}</span>
+        <button className={styles.notifBtn} type="button" aria-label="Notifications">
+          <Bell size={20} />
+        </button>
+      </div>
+
+      <div className={styles.content}>
+        {activeDest === 'board' && <MobileBoardView investigationId={invId} />}
+        {activeDest === 'evidence' && <MobileEvidenceList investigationId={invId} />}
+        {activeDest === 'activity' && <InvestigationActivityFeed investigationId={invId} compact />}
+      </div>
+
+      <MobileBottomNav
+        activeDest={activeDest}
+        onSetActiveDest={setActiveDest}
+        onCapture={() => setCaptureOpen(true)}
+        onMore={() => setMoreOpen(true)}
+      />
+
+      {captureOpen && (
+        <EvidenceCaptureSheet
+          investigationId={invId}
+          onClose={() => setCaptureOpen(false)}
+          onSaved={handleEvidenceSaved}
+        />
+      )}
+
+      {moreOpen && (
+        <MobileMoreDrawer onSelectTool={handleSelectMore} onClose={() => setMoreOpen(false)} />
+      )}
+    </div>
+  );
+}

--- a/src/client/components/investigation/mobile/MobileMoreDrawer.module.css
+++ b/src/client/components/investigation/mobile/MobileMoreDrawer.module.css
@@ -1,0 +1,88 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 120;
+  display: flex;
+  align-items: flex-end;
+}
+
+.sheet {
+  width: 100%;
+  background: var(--glass-bg-strong);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  padding-bottom: env(safe-area-inset-bottom);
+  overflow: hidden;
+}
+
+.dragHandle {
+  width: 36px;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.18);
+  border-radius: 2px;
+  margin: 0.75rem auto;
+}
+
+.title {
+  font-size: 0.75rem;
+  font-weight: 800;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0 1rem 0.75rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 0.875rem 1rem;
+  border-top: 1px solid var(--glass-border);
+  background: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.row:active {
+  background: var(--glass-bg-highlight);
+}
+
+.iconBox {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius-base);
+  background: var(--glass-bg-highlight);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.rowBody {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.rowTitle {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.rowSubtitle {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+}
+
+.chevron {
+  color: var(--text-muted);
+}

--- a/src/client/components/investigation/mobile/MobileMoreDrawer.tsx
+++ b/src/client/components/investigation/mobile/MobileMoreDrawer.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Calendar, Microscope, MessageSquare, Target, Download, ChevronRight } from 'lucide-react';
+import styles from './MobileMoreDrawer.module.css';
+
+export type MoreTool = 'timeline' | 'forensic' | 'communications' | 'hypotheses' | 'export';
+
+interface ToolEntry {
+  id: MoreTool;
+  title: string;
+  subtitle: string;
+  Icon: React.ElementType;
+}
+
+const TOOLS: ToolEntry[] = [
+  { id: 'timeline', title: 'Event Chronology', subtitle: 'Timeline of events', Icon: Calendar },
+  {
+    id: 'forensic',
+    title: 'Forensic Workbench',
+    subtitle: 'Document analysis, network',
+    Icon: Microscope,
+  },
+  {
+    id: 'communications',
+    title: 'Communications',
+    subtitle: 'Pattern analysis',
+    Icon: MessageSquare,
+  },
+  { id: 'hypotheses', title: 'Hypotheses', subtitle: 'Test and refine theories', Icon: Target },
+  {
+    id: 'export',
+    title: 'Export & Report',
+    subtitle: 'Generate forensic report',
+    Icon: Download,
+  },
+];
+
+interface MobileMoreDrawerProps {
+  onSelectTool: (tool: MoreTool) => void;
+  onClose: () => void;
+}
+
+export function MobileMoreDrawer({ onSelectTool, onClose }: MobileMoreDrawerProps) {
+  return (
+    <div className={styles.backdrop} onClick={onClose}>
+      <div className={styles.sheet} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.dragHandle} />
+        <div className={styles.title}>More Tools</div>
+        {TOOLS.map(({ id, title, subtitle, Icon }) => (
+          <button
+            key={id}
+            className={styles.row}
+            type="button"
+            onClick={() => {
+              onSelectTool(id);
+              onClose();
+            }}
+          >
+            <div className={styles.iconBox}>
+              <Icon size={18} />
+            </div>
+            <div className={styles.rowBody}>
+              <span className={styles.rowTitle}>{title}</span>
+              <span className={styles.rowSubtitle}>{subtitle}</span>
+            </div>
+            <ChevronRight size={16} className={styles.chevron} />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/investigation/mobile/MobileTimelineView.module.css
+++ b/src/client/components/investigation/mobile/MobileTimelineView.module.css
@@ -1,0 +1,173 @@
+.root {
+  height: 100%;
+  overflow-y: auto;
+  padding: 0.75rem 1rem 1rem;
+}
+
+.yearGroup {
+  margin-bottom: 1rem;
+}
+
+.yearDivider {
+  font-size: 0.75rem;
+  font-weight: 800;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 0.5rem 0 0.375rem;
+  border-bottom: 1px solid var(--glass-border);
+  margin-bottom: 0.5rem;
+}
+
+.eventRow {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.625rem 0;
+  border: none;
+  background: none;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
+  align-items: flex-start;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 0.3rem;
+  flex-shrink: 0;
+  background: var(--dot-color, var(--text-muted));
+}
+
+.eventBody {
+  flex: 1;
+}
+
+.eventMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.25rem;
+}
+
+.date {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.typeBadge {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  padding: 0.125rem 0.4375rem;
+  border-radius: 100px;
+  background: var(--glass-bg-highlight);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.eventTitle {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.eventDetail {
+  padding: 0.625rem 0 0.25rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.addSheet {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 300;
+  display: flex;
+  align-items: flex-end;
+}
+
+.addSheetInner {
+  width: 100%;
+  background: var(--glass-bg-strong);
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  padding: 1.5rem 1rem calc(1.5rem + env(safe-area-inset-bottom));
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.addSheetTitle {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.sheetInput {
+  width: 100%;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.sheetInput:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.sheetSelect {
+  width: 100%;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+  padding: 0.75rem;
+  box-sizing: border-box;
+  cursor: pointer;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.sheetSaveBtn {
+  width: 100%;
+  padding: 0.875rem;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-base);
+  color: var(--text-on-accent, #fff);
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.sheetSaveBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.sheetError {
+  color: var(--accent-red);
+  font-size: 0.875rem;
+}
+
+.emptyState {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 3rem 1rem;
+  font-size: 0.9375rem;
+}

--- a/src/client/components/investigation/mobile/MobileTimelineView.tsx
+++ b/src/client/components/investigation/mobile/MobileTimelineView.tsx
@@ -1,0 +1,163 @@
+import React, { useState, useCallback } from 'react';
+import type { TimelineEvent } from '../../../types/investigation';
+import { apiClient } from '../../../services/apiClient';
+import styles from './MobileTimelineView.module.css';
+
+const EVENT_TYPE_COLORS: Record<string, string> = {
+  document: 'var(--accent)',
+  meeting: 'var(--accent-yellow)',
+  location: 'var(--accent-green)',
+  communication: '#8b5cf6',
+  hypothesis: 'var(--accent-red)',
+  other: 'var(--text-muted)',
+};
+
+const EVENT_TYPES = ['document', 'meeting', 'location', 'communication', 'hypothesis', 'other'];
+
+interface MobileTimelineViewProps {
+  investigationId: string;
+  timelineEvents: TimelineEvent[];
+  onEventsChanged?: () => void;
+}
+
+export function MobileTimelineView({
+  investigationId,
+  timelineEvents,
+  onEventsChanged,
+}: MobileTimelineViewProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const [newDate, setNewDate] = useState('');
+  const [newTitle, setNewTitle] = useState('');
+  const [newType, setNewType] = useState('other');
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Group events by year
+  const byYear = timelineEvents.reduce<Record<string, TimelineEvent[]>>((acc, evt) => {
+    const year = new Date(evt.startDate).getFullYear().toString();
+    if (!acc[year]) acc[year] = [];
+    acc[year].push(evt);
+    return acc;
+  }, {});
+
+  const sortedYears = Object.keys(byYear).sort((a, b) => Number(b) - Number(a));
+
+  const handleSaveEvent = useCallback(async () => {
+    if (!newTitle.trim() || !newDate) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await apiClient.post(`/investigations/${investigationId}/timeline-events`, {
+        title: newTitle,
+        start_date: newDate,
+        type: newType,
+      });
+      setAddOpen(false);
+      setNewTitle('');
+      setNewDate('');
+      setNewType('other');
+      onEventsChanged?.();
+    } catch (err) {
+      console.error('Timeline event save failed:', err);
+      setSaveError('Failed to save event. Please try again.');
+    } finally {
+      setSaving(false);
+    }
+  }, [investigationId, newTitle, newDate, newType, onEventsChanged]);
+
+  const handleCloseSheet = useCallback(() => {
+    setAddOpen(false);
+    setNewTitle('');
+    setNewDate('');
+    setSaveError(null);
+  }, []);
+
+  return (
+    <>
+      <div className={styles.root}>
+        {sortedYears.map((year) => (
+          <div key={year} className={styles.yearGroup}>
+            <div className={styles.yearDivider}>{year}</div>
+            {byYear[year].map((evt) => (
+              <div key={evt.id}>
+                <button
+                  className={styles.eventRow}
+                  onClick={() => setExpandedId(expandedId === evt.id ? null : evt.id)}
+                  aria-expanded={expandedId === evt.id}
+                >
+                  <span
+                    className={styles.dot}
+                    style={
+                      {
+                        '--dot-color': EVENT_TYPE_COLORS[evt.type] ?? EVENT_TYPE_COLORS.other,
+                      } as React.CSSProperties
+                    }
+                  />
+                  <div className={styles.eventBody}>
+                    <div className={styles.eventMeta}>
+                      <span className={styles.date}>
+                        {new Date(evt.startDate).toLocaleDateString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                        })}
+                      </span>
+                      <span className={styles.typeBadge}>{evt.type}</span>
+                    </div>
+                    <div className={styles.eventTitle}>{evt.title}</div>
+                  </div>
+                </button>
+                {expandedId === evt.id && evt.description && (
+                  <div className={styles.eventDetail}>{evt.description}</div>
+                )}
+              </div>
+            ))}
+          </div>
+        ))}
+        {sortedYears.length === 0 && (
+          <div className={styles.emptyState}>No timeline events yet</div>
+        )}
+      </div>
+
+      {addOpen && (
+        <div className={styles.addSheet} onClick={handleCloseSheet}>
+          <div className={styles.addSheetInner} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.addSheetTitle}>Add Event</div>
+            <input
+              type="date"
+              className={styles.sheetInput}
+              value={newDate}
+              onChange={(e) => setNewDate(e.target.value)}
+            />
+            <input
+              type="text"
+              className={styles.sheetInput}
+              placeholder="Event title"
+              value={newTitle}
+              onChange={(e) => setNewTitle(e.target.value)}
+            />
+            <select
+              className={styles.sheetSelect}
+              value={newType}
+              onChange={(e) => setNewType(e.target.value)}
+            >
+              {EVENT_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {t.charAt(0).toUpperCase() + t.slice(1)}
+                </option>
+              ))}
+            </select>
+            {saveError !== null && <p className={styles.sheetError}>{saveError}</p>}
+            <button
+              className={styles.sheetSaveBtn}
+              disabled={!newTitle.trim() || !newDate || saving}
+              onClick={handleSaveEvent}
+            >
+              {saving ? 'Saving\u2026' : 'Save Event'}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/client/components/investigation/mobile/MobileTimelineView.tsx
+++ b/src/client/components/investigation/mobile/MobileTimelineView.tsx
@@ -107,8 +107,20 @@ export function MobileTimelineView({
                     <div className={styles.eventTitle}>{evt.title}</div>
                   </div>
                 </button>
-                {expandedId === evt.id && evt.description && (
-                  <div className={styles.eventDetail}>{evt.description}</div>
+                {expandedId === evt.id && (
+                  <div className={styles.eventDetail}>
+                    {evt.description && <p>{evt.description}</p>}
+                    {evt.entities.length > 0 && (
+                      <p>
+                        <strong>Entities:</strong> {evt.entities.join(', ')}
+                      </p>
+                    )}
+                    {evt.documents.length > 0 && (
+                      <p>
+                        <strong>Documents:</strong> {evt.documents.length} linked
+                      </p>
+                    )}
+                  </div>
                 )}
               </div>
             ))}

--- a/src/client/components/investigation/mobile/MobileToolScreen.module.css
+++ b/src/client/components/investigation/mobile/MobileToolScreen.module.css
@@ -1,0 +1,77 @@
+.root {
+  position: fixed;
+  inset: 0;
+  background: var(--glass-bg-strong);
+  z-index: 150;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transform: translateY(var(--swipe-y, 0px));
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.875rem 1rem;
+  padding-top: calc(0.875rem + env(safe-area-inset-top));
+  border-bottom: 1px solid var(--glass-border);
+  background: var(--glass-bg-strong);
+  flex-shrink: 0;
+}
+
+.backBtn {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  color: var(--accent);
+  font-size: 0.9375rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.breadcrumb {
+  font-size: 0.9375rem;
+  color: var(--text-muted);
+  flex: 1;
+}
+
+.toolName {
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.actionBtn {
+  background: none;
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-base);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.375rem 0.75rem;
+  min-height: 2.75rem;
+  font-family: inherit;
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.hint {
+  position: sticky;
+  bottom: 0;
+  padding: 0.625rem 1rem calc(0.625rem + env(safe-area-inset-bottom));
+  background: var(--glass-bg-strong);
+  border-top: 1px solid var(--glass-border);
+  text-align: center;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  cursor: pointer;
+}

--- a/src/client/components/investigation/mobile/MobileToolScreen.tsx
+++ b/src/client/components/investigation/mobile/MobileToolScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { ChevronLeft } from 'lucide-react';
 import styles from './MobileToolScreen.module.css';
 
@@ -22,14 +22,7 @@ export function MobileToolScreen({
 }: MobileToolScreenProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const touchStartY = useRef<number>(0);
-  const [showHint, setShowHint] = useState(false);
-
-  useEffect(() => {
-    const seen = localStorage.getItem(HINT_KEY);
-    if (!seen) {
-      setShowHint(true);
-    }
-  }, []);
+  const [showHint, setShowHint] = useState<boolean>(() => localStorage.getItem(HINT_KEY) === null);
 
   const dismissHint = useCallback(() => {
     localStorage.setItem(HINT_KEY, '1');

--- a/src/client/components/investigation/mobile/MobileToolScreen.tsx
+++ b/src/client/components/investigation/mobile/MobileToolScreen.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { ChevronLeft } from 'lucide-react';
+import styles from './MobileToolScreen.module.css';
+
+const SWIPE_DISMISS_THRESHOLD = 80;
+const HINT_KEY = 'mobile-tool-hint-seen';
+
+interface MobileToolScreenProps {
+  toolName: string;
+  onBack: () => void;
+  actionLabel?: string;
+  onAction?: () => void;
+  children: React.ReactNode;
+}
+
+export function MobileToolScreen({
+  toolName,
+  onBack,
+  actionLabel,
+  onAction,
+  children,
+}: MobileToolScreenProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const touchStartY = useRef<number>(0);
+  const [showHint, setShowHint] = useState(false);
+
+  useEffect(() => {
+    const seen = localStorage.getItem(HINT_KEY);
+    if (!seen) {
+      setShowHint(true);
+    }
+  }, []);
+
+  const dismissHint = useCallback(() => {
+    localStorage.setItem(HINT_KEY, '1');
+    setShowHint(false);
+  }, []);
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartY.current = e.touches[0].clientY;
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    const el = rootRef.current;
+    if (!el) return;
+    const deltaY = e.touches[0].clientY - touchStartY.current;
+    if (deltaY > 0) {
+      el.style.setProperty('--swipe-y', `${deltaY}px`);
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      const el = rootRef.current;
+      if (!el) return;
+      const deltaY = e.changedTouches[0].clientY - touchStartY.current;
+      if (deltaY >= SWIPE_DISMISS_THRESHOLD) {
+        el.style.removeProperty('--swipe-y');
+        onBack();
+      } else {
+        el.style.removeProperty('--swipe-y');
+      }
+    },
+    [onBack],
+  );
+
+  return (
+    <div
+      ref={rootRef}
+      className={styles.root}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className={styles.header}>
+        <button className={styles.backBtn} onClick={onBack} type="button">
+          <ChevronLeft size={20} />
+          Back
+        </button>
+        <span className={styles.breadcrumb}>
+          <span className={styles.toolName}>{toolName}</span>
+        </span>
+        {actionLabel && onAction && (
+          <button className={styles.actionBtn} onClick={onAction} type="button">
+            {actionLabel}
+          </button>
+        )}
+      </div>
+
+      <div className={styles.content}>{children}</div>
+
+      {showHint && (
+        <div className={styles.hint} onClick={dismissHint}>
+          Swipe down to dismiss
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/hooks/useIsMobile.ts
+++ b/src/client/hooks/useIsMobile.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react';
+
+const MOBILE_QUERY = '(max-width: 767px)';
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(MOBILE_QUERY).matches;
+  });
+
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Summary

- Adds `MobileInvestigationShell` — a full mobile layout rendered on viewports ≤767px in place of the desktop sidebar/tab UI, detected via a new `useIsMobile()` hook
- Bottom nav (5 slots + elevated capture FAB) with a swipe-capable board view, evidence list, activity feed, and a "More" drawer for secondary tools (timeline, forensics, communications, hypotheses, export)
- `EvidenceCaptureSheet` — full-screen portal bottom sheet with Note / File / URL capture modes, swipe-down dismiss via CSS custom property, and toast confirmation on save

## Changed files

| Area | Files |
|---|---|
| New hook | `src/client/hooks/useIsMobile.ts` |
| Mobile shell | `mobile/MobileInvestigationShell.tsx/.css` |
| Navigation | `mobile/MobileBottomNav.tsx/.css`, `mobile/MobileMoreDrawer.tsx/.css`, `mobile/MobileToolScreen.tsx/.css` |
| Capture | `mobile/EvidenceCaptureSheet.tsx/.css` |
| Views | `mobile/MobileBoardView.tsx/.css`, `mobile/MobileEvidenceList.tsx/.css`, `mobile/MobileTimelineView.tsx/.css`, `mobile/MobileForensicView.tsx/.css` |
| Desktop tools | `ForensicDocumentAnalyzer`, `MultiSourceCorrelationEngine`, `ForensicReportGenerator`, `CommunicationAnalysis`, `HypothesisTestingFramework` — each gains `mobileMode?: boolean` to hide internal chrome |
| Wiring | `InvestigationWorkspace.tsx` — `useIsMobile()` + conditional render |

## Test plan

- [ ] Desktop (≥768px): `InvestigationWorkspace` renders unchanged — sidebar and tab layout intact
- [ ] Mobile (≤767px, e.g. iPhone 14 390px in DevTools): bottom nav renders with 5 slots and elevated FAB
- [ ] Board / Evidence / Activity tabs switch content area
- [ ] Capture FAB opens sheet; Note/File/URL mode tabs work; swipe-down dismisses; saved evidence shows success toast
- [ ] More drawer opens; tapping a tool opens `MobileToolScreen` with back nav; swipe-down returns to main
- [ ] Resizing from mobile → desktop (drag DevTools viewport) switches back to desktop layout without error
- [ ] `pnpm type-check` — 0 errors
- [ ] `pnpm test:smoke` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)